### PR TITLE
Enable pmnull module for rsyslog package

### DIFF
--- a/rsyslog/precise/master/debian/rules
+++ b/rsyslog/precise/master/debian/rules
@@ -27,6 +27,7 @@ override_dh_auto_configure:
 		--enable-pmlastmsg \
 		--enable-pmrfc3164sd \
 		--enable-pmsnare \
+		--enable-pmnull \
 		--enable-omprog \
                 --enable-elasticsearch \
                 --enable-mmjsonparse \

--- a/rsyslog/precise/v8-stable/debian/rules
+++ b/rsyslog/precise/v8-stable/debian/rules
@@ -27,6 +27,7 @@ override_dh_auto_configure:
 		--enable-pmlastmsg \
 		--enable-pmrfc3164sd \
 		--enable-pmsnare \
+		--enable-pmnull \
 		--enable-omprog \
                 --enable-elasticsearch \
                 --enable-mmjsonparse \

--- a/rsyslog/trusty/master/debian/rules
+++ b/rsyslog/trusty/master/debian/rules
@@ -27,6 +27,7 @@ override_dh_auto_configure:
 		--enable-pmlastmsg \
 		--enable-pmrfc3164sd \
 		--enable-pmsnare \
+		--enable-pmnull \
 		--enable-omprog \
                 --enable-elasticsearch \
                 --enable-mmjsonparse \

--- a/rsyslog/trusty/v8-stable/debian/rules
+++ b/rsyslog/trusty/v8-stable/debian/rules
@@ -27,6 +27,7 @@ override_dh_auto_configure:
 		--enable-pmlastmsg \
 		--enable-pmrfc3164sd \
 		--enable-pmsnare \
+		--enable-pmnull \
 		--enable-omprog \
                 --enable-elasticsearch \
                 --enable-mmjsonparse \

--- a/rsyslog/wily/master/debian/rules
+++ b/rsyslog/wily/master/debian/rules
@@ -25,6 +25,7 @@ override_dh_auto_configure:
 		--enable-pmlastmsg \
 		--enable-pmrfc3164sd \
 		--enable-pmsnare \
+		--enable-pmnull \
 		--enable-omprog \
 		--enable-elasticsearch \
 		--enable-mmjsonparse \

--- a/rsyslog/wily/v8-stable/debian/rules
+++ b/rsyslog/wily/v8-stable/debian/rules
@@ -25,6 +25,7 @@ override_dh_auto_configure:
 		--enable-pmlastmsg \
 		--enable-pmrfc3164sd \
 		--enable-pmsnare \
+		--enable-pmnull \
 		--enable-omprog \
 		--enable-elasticsearch \
 		--enable-mmjsonparse \

--- a/rsyslog/xenial/master/debian/rules
+++ b/rsyslog/xenial/master/debian/rules
@@ -25,6 +25,7 @@ override_dh_auto_configure:
 		--enable-pmlastmsg \
 		--enable-pmrfc3164sd \
 		--enable-pmsnare \
+		--enable-pmnull \
 		--enable-omprog \
 		--enable-elasticsearch \
 		--enable-mmjsonparse \

--- a/rsyslog/xenial/v8-stable-testing/debian/rules
+++ b/rsyslog/xenial/v8-stable-testing/debian/rules
@@ -25,6 +25,7 @@ override_dh_auto_configure:
 		--enable-pmlastmsg \
 		--enable-pmrfc3164sd \
 		--enable-pmsnare \
+		--enable-pmnull \
 		--enable-omprog \
 		--enable-elasticsearch \
 		--enable-mmjsonparse \

--- a/rsyslog/xenial/v8-stable/debian/rules
+++ b/rsyslog/xenial/v8-stable/debian/rules
@@ -25,6 +25,7 @@ override_dh_auto_configure:
 		--enable-pmlastmsg \
 		--enable-pmrfc3164sd \
 		--enable-pmsnare \
+		--enable-pmnull \
 		--enable-omprog \
 		--enable-elasticsearch \
 		--enable-mmjsonparse \

--- a/rsyslog/yakkety/master/debian/rules
+++ b/rsyslog/yakkety/master/debian/rules
@@ -25,6 +25,7 @@ override_dh_auto_configure:
 		--enable-pmlastmsg \
 		--enable-pmrfc3164sd \
 		--enable-pmsnare \
+		--enable-pmnull \
 		--enable-omprog \
 		--enable-elasticsearch \
 		--enable-mmjsonparse \

--- a/rsyslog/yakkety/v8-stable-testing/debian/rules
+++ b/rsyslog/yakkety/v8-stable-testing/debian/rules
@@ -25,6 +25,7 @@ override_dh_auto_configure:
 		--enable-pmlastmsg \
 		--enable-pmrfc3164sd \
 		--enable-pmsnare \
+		--enable-pmnull \
 		--enable-omprog \
 		--enable-elasticsearch \
 		--enable-mmjsonparse \

--- a/rsyslog/yakkety/v8-stable/debian/rules
+++ b/rsyslog/yakkety/v8-stable/debian/rules
@@ -25,6 +25,7 @@ override_dh_auto_configure:
 		--enable-pmlastmsg \
 		--enable-pmrfc3164sd \
 		--enable-pmsnare \
+		--enable-pmnull \
 		--enable-omprog \
 		--enable-elasticsearch \
 		--enable-mmjsonparse \

--- a/rsyslog/zesty/master/debian/rules
+++ b/rsyslog/zesty/master/debian/rules
@@ -25,6 +25,7 @@ override_dh_auto_configure:
 		--enable-pmlastmsg \
 		--enable-pmrfc3164sd \
 		--enable-pmsnare \
+		--enable-pmnull \
 		--enable-omprog \
 		--enable-elasticsearch \
 		--enable-mmjsonparse \

--- a/rsyslog/zesty/v8-stable-testing/debian/rules
+++ b/rsyslog/zesty/v8-stable-testing/debian/rules
@@ -25,6 +25,7 @@ override_dh_auto_configure:
 		--enable-pmlastmsg \
 		--enable-pmrfc3164sd \
 		--enable-pmsnare \
+		--enable-pmnull \
 		--enable-omprog \
 		--enable-elasticsearch \
 		--enable-mmjsonparse \

--- a/rsyslog/zesty/v8-stable/debian/rules
+++ b/rsyslog/zesty/v8-stable/debian/rules
@@ -25,6 +25,7 @@ override_dh_auto_configure:
 		--enable-pmlastmsg \
 		--enable-pmrfc3164sd \
 		--enable-pmsnare \
+		--enable-pmnull \
 		--enable-omprog \
 		--enable-elasticsearch \
 		--enable-mmjsonparse \


### PR DESCRIPTION
It's very useful module. I am reading messages from files to transfer them over network, and I don't want standard parser to mess it up, if messages happens to resemble syslog format. Also I don't want to loose performance on unnecessary parsing. No big deal, just feels sloppy.

I turned on `--enable-pmnull` option in `debian/riles` files. All `rsyslog.install` files have lines with `pm*.so`, so there is no need to update them - all parser modules should be always installed.