### PR TITLE
Fix libhiredis package dependency for rsyslog-redis on artful, xenial, and zesty

### DIFF
--- a/rsyslog/artful/master/debian/control
+++ b/rsyslog/artful/master/debian/control
@@ -294,7 +294,7 @@ Priority: extra
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          rsyslog (= ${binary:Version}),
-         libhiredis0.10
+         libhiredis0.13
 Description: This module implements Redis support, permitting ryslog to write to redis.
 
 Package: rsyslog-omstdout

--- a/rsyslog/artful/v8-stable/debian/control
+++ b/rsyslog/artful/v8-stable/debian/control
@@ -294,7 +294,7 @@ Priority: extra
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          rsyslog (= ${binary:Version}),
-         libhiredis0.10
+         libhiredis0.13
 Description: This module implements Redis support, permitting ryslog to write to redis.
 
 Package: rsyslog-omstdout

--- a/rsyslog/xenial/master/debian/control
+++ b/rsyslog/xenial/master/debian/control
@@ -295,7 +295,7 @@ Priority: extra
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          rsyslog (= ${binary:Version}),
-         libhiredis0.10
+         libhiredis0.13
 Description: This module implements Redis support, permitting ryslog to write to redis.
 
 Package: rsyslog-omstdout

--- a/rsyslog/xenial/v8-stable/debian/control
+++ b/rsyslog/xenial/v8-stable/debian/control
@@ -295,7 +295,7 @@ Priority: extra
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          rsyslog (= ${binary:Version}),
-         libhiredis0.10
+         libhiredis0.13
 Description: This module implements Redis support, permitting ryslog to write to redis.
 
 Package: rsyslog-omstdout

--- a/rsyslog/zesty/master/debian/control
+++ b/rsyslog/zesty/master/debian/control
@@ -282,7 +282,7 @@ Priority: extra
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          rsyslog (= ${binary:Version}),
-         libhiredis0.10
+         libhiredis0.13
 Description: This module implements Redis support, permitting ryslog to write to redis.
 
 Package: rsyslog-omstdout

--- a/rsyslog/zesty/v8-stable/debian/control
+++ b/rsyslog/zesty/v8-stable/debian/control
@@ -283,7 +283,7 @@ Priority: extra
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          rsyslog (= ${binary:Version}),
-         libhiredis0.10
+         libhiredis0.13
 Description: This module implements Redis support, permitting ryslog to write to redis.
 
 Package: rsyslog-omstdout


### PR DESCRIPTION
The package name for all distros after trusty (including bionic) is `libhiredis0.13`