### PR TITLE
Rebuild of rsyslog to add pmnormalize subpackage on bionic and xenial

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Sub-packages for rsyslog to provide specific functionality:
 - rsyslog-mongodb (>=16.04)
 - rsyslog-mysql
 - rsyslog-pgsql
+- rsyslog-pmnormalize (>=16.04)
 - rsyslog-relp
 - rsyslog-utils
 

--- a/rsyslog/bionic/master/debian/control
+++ b/rsyslog/bionic/master/debian/control
@@ -259,6 +259,16 @@ Description: TLS protocol support for rsyslog
  This netstream plugin allows rsyslog to send and receive encrypted syslog
  messages via the upcoming syslog-transport-tls IETF standard protocol.
 
+Package: rsyslog-pmnormalize
+Architecture: any
+Priority: extra
+Depends: ${shlibs:Depends},
+         ${misc:Depends},
+         rsyslog (= ${binary:Version}),
+         liblognorm5
+Description: The rsyslog-pmnormalize package provides a parser module based
+ on log normalization using the liblognorm and its Rulebase format.
+
 Package: rsyslog-utils
 Architecture: any
 Priority: extra

--- a/rsyslog/bionic/master/debian/rsyslog-pmnormalize.install
+++ b/rsyslog/bionic/master/debian/rsyslog-pmnormalize.install
@@ -1,0 +1,1 @@
+debian/tmp/usr/lib/rsyslog/pmnormalize.so

--- a/rsyslog/bionic/master/debian/rules
+++ b/rsyslog/bionic/master/debian/rules
@@ -37,6 +37,7 @@ override_dh_auto_configure:
 		--enable-mmsequence \
 		--enable-mmutf8fix \
 		--enable-pmciscoios \
+		--enable-pmnormalize \
 		--enable-usertools \
 		--enable-imjournal \
 		--enable-omjournal \

--- a/rsyslog/bionic/v8-stable/debian/control
+++ b/rsyslog/bionic/v8-stable/debian/control
@@ -259,6 +259,16 @@ Description: TLS protocol support for rsyslog
  This netstream plugin allows rsyslog to send and receive encrypted syslog
  messages via the upcoming syslog-transport-tls IETF standard protocol.
 
+Package: rsyslog-pmnormalize
+Architecture: any
+Priority: extra
+Depends: ${shlibs:Depends},
+         ${misc:Depends},
+         rsyslog (= ${binary:Version}),
+         liblognorm5
+Description: The rsyslog-pmnormalize package provides a parser module based
+ on log normalization using the liblognorm and its Rulebase format.
+
 Package: rsyslog-utils
 Architecture: any
 Priority: extra

--- a/rsyslog/bionic/v8-stable/debian/rsyslog-pmnormalize.install
+++ b/rsyslog/bionic/v8-stable/debian/rsyslog-pmnormalize.install
@@ -1,0 +1,1 @@
+debian/tmp/usr/lib/rsyslog/pmnormalize.so

--- a/rsyslog/bionic/v8-stable/debian/rules
+++ b/rsyslog/bionic/v8-stable/debian/rules
@@ -37,6 +37,7 @@ override_dh_auto_configure:
 		--enable-mmsequence \
 		--enable-mmutf8fix \
 		--enable-pmciscoios \
+		--enable-pmnormalize \
 		--enable-usertools \
 		--enable-imjournal \
 		--enable-omjournal \

--- a/rsyslog/cosmic/master/debian/control
+++ b/rsyslog/cosmic/master/debian/control
@@ -259,6 +259,16 @@ Description: TLS protocol support for rsyslog
  This netstream plugin allows rsyslog to send and receive encrypted syslog
  messages via the upcoming syslog-transport-tls IETF standard protocol.
 
+Package: rsyslog-pmnormalize
+Architecture: any
+Priority: extra
+Depends: ${shlibs:Depends},
+         ${misc:Depends},
+         rsyslog (= ${binary:Version}),
+         liblognorm5
+Description: The rsyslog-pmnormalize package provides a parser module based
+ on log normalization using the liblognorm and its Rulebase format.
+
 Package: rsyslog-utils
 Architecture: any
 Priority: extra

--- a/rsyslog/cosmic/master/debian/rsyslog-pmnormalize.install
+++ b/rsyslog/cosmic/master/debian/rsyslog-pmnormalize.install
@@ -1,0 +1,1 @@
+debian/tmp/usr/lib/rsyslog/pmnormalize.so

--- a/rsyslog/cosmic/master/debian/rules
+++ b/rsyslog/cosmic/master/debian/rules
@@ -37,6 +37,7 @@ override_dh_auto_configure:
 		--enable-mmsequence \
 		--enable-mmutf8fix \
 		--enable-pmciscoios \
+		--enable-pmnormalize \
 		--enable-usertools \
 		--enable-imjournal \
 		--enable-omjournal \

--- a/rsyslog/cosmic/v8-stable/debian/control
+++ b/rsyslog/cosmic/v8-stable/debian/control
@@ -259,6 +259,16 @@ Description: TLS protocol support for rsyslog
  This netstream plugin allows rsyslog to send and receive encrypted syslog
  messages via the upcoming syslog-transport-tls IETF standard protocol.
 
+Package: rsyslog-pmnormalize
+Architecture: any
+Priority: extra
+Depends: ${shlibs:Depends},
+         ${misc:Depends},
+         rsyslog (= ${binary:Version}),
+         liblognorm5
+Description: The rsyslog-pmnormalize package provides a parser module based
+ on log normalization using the liblognorm and its Rulebase format.
+
 Package: rsyslog-utils
 Architecture: any
 Priority: extra

--- a/rsyslog/cosmic/v8-stable/debian/rsyslog-pmnormalize.install
+++ b/rsyslog/cosmic/v8-stable/debian/rsyslog-pmnormalize.install
@@ -1,0 +1,1 @@
+debian/tmp/usr/lib/rsyslog/pmnormalize.so

--- a/rsyslog/cosmic/v8-stable/debian/rules
+++ b/rsyslog/cosmic/v8-stable/debian/rules
@@ -37,6 +37,7 @@ override_dh_auto_configure:
 		--enable-mmsequence \
 		--enable-mmutf8fix \
 		--enable-pmciscoios \
+		--enable-pmnormalize \
 		--enable-usertools \
 		--enable-imjournal \
 		--enable-omjournal \

--- a/rsyslog/disco/master/debian/control
+++ b/rsyslog/disco/master/debian/control
@@ -259,6 +259,16 @@ Description: TLS protocol support for rsyslog
  This netstream plugin allows rsyslog to send and receive encrypted syslog
  messages via the upcoming syslog-transport-tls IETF standard protocol.
 
+Package: rsyslog-pmnormalize
+Architecture: any
+Priority: extra
+Depends: ${shlibs:Depends},
+         ${misc:Depends},
+         rsyslog (= ${binary:Version}),
+         liblognorm5
+Description: The rsyslog-pmnormalize package provides a parser module based
+ on log normalization using the liblognorm and its Rulebase format.
+
 Package: rsyslog-utils
 Architecture: any
 Priority: extra

--- a/rsyslog/disco/master/debian/rsyslog-pmnormalize.install
+++ b/rsyslog/disco/master/debian/rsyslog-pmnormalize.install
@@ -1,0 +1,1 @@
+debian/tmp/usr/lib/rsyslog/pmnormalize.so

--- a/rsyslog/disco/master/debian/rules
+++ b/rsyslog/disco/master/debian/rules
@@ -37,6 +37,7 @@ override_dh_auto_configure:
 		--enable-mmsequence \
 		--enable-mmutf8fix \
 		--enable-pmciscoios \
+		--enable-pmnormalize \
 		--enable-usertools \
 		--enable-imjournal \
 		--enable-omjournal \

--- a/rsyslog/disco/v8-stable/debian/control
+++ b/rsyslog/disco/v8-stable/debian/control
@@ -259,6 +259,16 @@ Description: TLS protocol support for rsyslog
  This netstream plugin allows rsyslog to send and receive encrypted syslog
  messages via the upcoming syslog-transport-tls IETF standard protocol.
 
+Package: rsyslog-pmnormalize
+Architecture: any
+Priority: extra
+Depends: ${shlibs:Depends},
+         ${misc:Depends},
+         rsyslog (= ${binary:Version}),
+         liblognorm5
+Description: The rsyslog-pmnormalize package provides a parser module based
+ on log normalization using the liblognorm and its Rulebase format.
+
 Package: rsyslog-utils
 Architecture: any
 Priority: extra

--- a/rsyslog/disco/v8-stable/debian/rsyslog-pmnormalize.install
+++ b/rsyslog/disco/v8-stable/debian/rsyslog-pmnormalize.install
@@ -1,0 +1,1 @@
+debian/tmp/usr/lib/rsyslog/pmnormalize.so

--- a/rsyslog/disco/v8-stable/debian/rules
+++ b/rsyslog/disco/v8-stable/debian/rules
@@ -37,6 +37,7 @@ override_dh_auto_configure:
 		--enable-mmsequence \
 		--enable-mmutf8fix \
 		--enable-pmciscoios \
+		--enable-pmnormalize \
 		--enable-usertools \
 		--enable-imjournal \
 		--enable-omjournal \

--- a/rsyslog/xenial/master/debian/control
+++ b/rsyslog/xenial/master/debian/control
@@ -260,6 +260,16 @@ Description: TLS protocol support for rsyslog
  This netstream plugin allows rsyslog to send and receive encrypted syslog
  messages via the upcoming syslog-transport-tls IETF standard protocol.
 
+Package: rsyslog-pmnormalize
+Architecture: any
+Priority: extra
+Depends: ${shlibs:Depends},
+         ${misc:Depends},
+         rsyslog (= ${binary:Version}),
+         liblognorm5
+Description: The rsyslog-pmnormalize package provides a parser module based
+ on log normalization using the liblognorm and its Rulebase format.
+
 Package: rsyslog-utils
 Architecture: any
 Priority: extra

--- a/rsyslog/xenial/master/debian/rsyslog-pmnormalize.install
+++ b/rsyslog/xenial/master/debian/rsyslog-pmnormalize.install
@@ -1,0 +1,1 @@
+debian/tmp/usr/lib/rsyslog/pmnormalize.so

--- a/rsyslog/xenial/master/debian/rules
+++ b/rsyslog/xenial/master/debian/rules
@@ -37,6 +37,7 @@ override_dh_auto_configure:
 		--enable-mmsequence \
 		--enable-mmutf8fix \
 		--enable-pmciscoios \
+		--enable-pmnormalize \
 		--enable-usertools \
 		--enable-imjournal \
 		--enable-omjournal \

--- a/rsyslog/xenial/v8-stable/debian/control
+++ b/rsyslog/xenial/v8-stable/debian/control
@@ -260,6 +260,16 @@ Description: TLS protocol support for rsyslog
  This netstream plugin allows rsyslog to send and receive encrypted syslog
  messages via the upcoming syslog-transport-tls IETF standard protocol.
 
+Package: rsyslog-pmnormalize
+Architecture: any
+Priority: extra
+Depends: ${shlibs:Depends},
+         ${misc:Depends},
+         rsyslog (= ${binary:Version}),
+         liblognorm5
+Description: The rsyslog-pmnormalize package provides a parser module based
+ on log normalization using the liblognorm and its Rulebase format.
+
 Package: rsyslog-utils
 Architecture: any
 Priority: extra

--- a/rsyslog/xenial/v8-stable/debian/rsyslog-pmnormalize.install
+++ b/rsyslog/xenial/v8-stable/debian/rsyslog-pmnormalize.install
@@ -1,0 +1,1 @@
+debian/tmp/usr/lib/rsyslog/pmnormalize.so

--- a/rsyslog/xenial/v8-stable/debian/rules
+++ b/rsyslog/xenial/v8-stable/debian/rules
@@ -37,6 +37,7 @@ override_dh_auto_configure:
 		--enable-mmsequence \
 		--enable-mmutf8fix \
 		--enable-pmciscoios \
+		--enable-pmnormalize \
 		--enable-usertools \
 		--enable-imjournal \
 		--enable-omjournal \


### PR DESCRIPTION
Hello,
Sorry but I am not familiar with debian package builds, let me know if something is wrong or missing. In particular I am not sure at all about the v8-stable-testing or master trees, nor the changelog files (maybe it is autogenerated by your build system?).
This goes along with  rsyslog/rsyslog-pkg-rhel-centos#50
I could not test this!
Julien