### PR TITLE
liblogging-stdlog is no longer a dependency

### DIFF
--- a/rsyslog/cosmic/master/debian/control
+++ b/rsyslog/cosmic/master/debian/control
@@ -32,7 +32,6 @@ Build-Depends: debhelper (>= 8),
 	       libsasl2-dev,
 	       libssl-dev,
 	       libhiredis-dev,
-	       liblogging-stdlog-dev
 #	       libksi1-dev,
 Standards-Version: 3.9.2
 XSBC-Original-Vcs-Git: git://git.debian.org/git/collab-maint/rsyslog.git
@@ -51,8 +50,7 @@ Depends: ${shlibs:Depends},
          lsb-base (>= 3.2-14),
          adduser,
          ucf,
-	 libfastjson4,
-	 liblogging-stdlog1
+	 libfastjson4
 Recommends: logrotate
 Suggests: rsyslog-mysql | rsyslog-pgsql,
           rsyslog-doc,


### PR DESCRIPTION
It is only required to run the testbench.

see also #73