### PR TITLE
liblogging-stdlog is no longer a dependency

### DIFF
--- a/rsyslog/cosmic/v8-stable/debian/control
+++ b/rsyslog/cosmic/v8-stable/debian/control
@@ -31,9 +31,7 @@ Build-Depends: debhelper (>= 8),
 	       liblz4-dev,
 	       libsasl2-dev,
 	       libssl-dev,
-	       libhiredis-dev,
-	       liblogging-stdlog-dev
-#	       libksi1-dev,
+	       libhiredis-dev
 Standards-Version: 3.9.2
 XSBC-Original-Vcs-Git: git://git.debian.org/git/collab-maint/rsyslog.git
 XSBC-Original-Vcs-Browser: http://git.debian.org/?p=collab-maint/rsyslog.git;a=summary
@@ -51,12 +49,10 @@ Depends: ${shlibs:Depends},
          lsb-base (>= 3.2-14),
          adduser,
          ucf,
-	 libfastjson4 (>= 0.99.7),
-	 liblogging-stdlog1
+	 libfastjson4 (>= 0.99.7)
 Recommends: logrotate
 Suggests: rsyslog-mysql | rsyslog-pgsql,
           rsyslog-doc,
-#          rsyslog-gssapi,
           rsyslog-relp,
           rsyslog-elasticsearch,
           rsyslog-mmjsonparse,


### PR DESCRIPTION
It is only required for the testbench.

closes #73