### PR TITLE
Add 00rsyslog.conf to systemd packages

### DIFF
--- a/rsyslog/artful/master/debian/00rsyslog.conf
+++ b/rsyslog/artful/master/debian/00rsyslog.conf
@@ -1,0 +1,12 @@
+# Override systemd's default tmpfiles.d/var.conf to make /var/log writable by
+# the syslog group, so that rsyslog can run as user.
+# See tmpfiles.d(5) for details.
+
+# Type Path    Mode UID  GID  Age Argument
+z /var/log 0775 root syslog -
+z /var/log/auth.log 0640 syslog adm -
+z /var/log/mail.err 0640 syslog adm -
+z /var/log/mail.log 0640 syslog adm -
+z /var/log/kern.log 0640 syslog adm -
+z /var/log/syslog 0640 syslog adm -
+d /var/spool/rsyslog 0700 syslog adm -

--- a/rsyslog/artful/master/debian/rsyslog.install
+++ b/rsyslog/artful/master/debian/rsyslog.install
@@ -1,4 +1,5 @@
 debian/rsyslog.conf /etc/
+debian/00rsyslog.conf  usr/lib/tmpfiles.d/
 debian/50-default.conf /usr/share/rsyslog
 debian/tmp/usr/sbin/
 debian/tmp/usr/share/man/

--- a/rsyslog/artful/v8-stable/debian/00rsyslog.conf
+++ b/rsyslog/artful/v8-stable/debian/00rsyslog.conf
@@ -1,0 +1,12 @@
+# Override systemd's default tmpfiles.d/var.conf to make /var/log writable by
+# the syslog group, so that rsyslog can run as user.
+# See tmpfiles.d(5) for details.
+
+# Type Path    Mode UID  GID  Age Argument
+z /var/log 0775 root syslog -
+z /var/log/auth.log 0640 syslog adm -
+z /var/log/mail.err 0640 syslog adm -
+z /var/log/mail.log 0640 syslog adm -
+z /var/log/kern.log 0640 syslog adm -
+z /var/log/syslog 0640 syslog adm -
+d /var/spool/rsyslog 0700 syslog adm -

--- a/rsyslog/artful/v8-stable/debian/rsyslog.install
+++ b/rsyslog/artful/v8-stable/debian/rsyslog.install
@@ -1,4 +1,5 @@
 debian/rsyslog.conf /etc/
+debian/00rsyslog.conf  usr/lib/tmpfiles.d/
 debian/50-default.conf /usr/share/rsyslog
 debian/tmp/usr/sbin/
 debian/tmp/usr/share/man/

--- a/rsyslog/bionic/master/debian/00rsyslog.conf
+++ b/rsyslog/bionic/master/debian/00rsyslog.conf
@@ -1,0 +1,12 @@
+# Override systemd's default tmpfiles.d/var.conf to make /var/log writable by
+# the syslog group, so that rsyslog can run as user.
+# See tmpfiles.d(5) for details.
+
+# Type Path    Mode UID  GID  Age Argument
+z /var/log 0775 root syslog -
+z /var/log/auth.log 0640 syslog adm -
+z /var/log/mail.err 0640 syslog adm -
+z /var/log/mail.log 0640 syslog adm -
+z /var/log/kern.log 0640 syslog adm -
+z /var/log/syslog 0640 syslog adm -
+d /var/spool/rsyslog 0700 syslog adm -

--- a/rsyslog/bionic/master/debian/rsyslog.install
+++ b/rsyslog/bionic/master/debian/rsyslog.install
@@ -1,4 +1,5 @@
 debian/rsyslog.conf /etc/
+debian/00rsyslog.conf  usr/lib/tmpfiles.d/
 debian/50-default.conf /usr/share/rsyslog
 debian/tmp/usr/sbin/
 debian/tmp/usr/share/man/

--- a/rsyslog/bionic/v8-stable/debian/00rsyslog.conf
+++ b/rsyslog/bionic/v8-stable/debian/00rsyslog.conf
@@ -1,0 +1,12 @@
+# Override systemd's default tmpfiles.d/var.conf to make /var/log writable by
+# the syslog group, so that rsyslog can run as user.
+# See tmpfiles.d(5) for details.
+
+# Type Path    Mode UID  GID  Age Argument
+z /var/log 0775 root syslog -
+z /var/log/auth.log 0640 syslog adm -
+z /var/log/mail.err 0640 syslog adm -
+z /var/log/mail.log 0640 syslog adm -
+z /var/log/kern.log 0640 syslog adm -
+z /var/log/syslog 0640 syslog adm -
+d /var/spool/rsyslog 0700 syslog adm -

--- a/rsyslog/bionic/v8-stable/debian/rsyslog.install
+++ b/rsyslog/bionic/v8-stable/debian/rsyslog.install
@@ -1,4 +1,5 @@
 debian/rsyslog.conf /etc/
+debian/00rsyslog.conf  usr/lib/tmpfiles.d/
 debian/50-default.conf /usr/share/rsyslog
 debian/tmp/usr/sbin/
 debian/tmp/usr/share/man/

--- a/rsyslog/cosmic/master/debian/00rsyslog.conf
+++ b/rsyslog/cosmic/master/debian/00rsyslog.conf
@@ -1,0 +1,12 @@
+# Override systemd's default tmpfiles.d/var.conf to make /var/log writable by
+# the syslog group, so that rsyslog can run as user.
+# See tmpfiles.d(5) for details.
+
+# Type Path    Mode UID  GID  Age Argument
+z /var/log 0775 root syslog -
+z /var/log/auth.log 0640 syslog adm -
+z /var/log/mail.err 0640 syslog adm -
+z /var/log/mail.log 0640 syslog adm -
+z /var/log/kern.log 0640 syslog adm -
+z /var/log/syslog 0640 syslog adm -
+d /var/spool/rsyslog 0700 syslog adm -

--- a/rsyslog/cosmic/master/debian/rsyslog.install
+++ b/rsyslog/cosmic/master/debian/rsyslog.install
@@ -1,4 +1,5 @@
 debian/rsyslog.conf /etc/
+debian/00rsyslog.conf  usr/lib/tmpfiles.d/
 debian/50-default.conf /usr/share/rsyslog
 debian/tmp/usr/sbin/
 debian/tmp/usr/share/man/

--- a/rsyslog/cosmic/v8-stable/debian/00rsyslog.conf
+++ b/rsyslog/cosmic/v8-stable/debian/00rsyslog.conf
@@ -1,0 +1,12 @@
+# Override systemd's default tmpfiles.d/var.conf to make /var/log writable by
+# the syslog group, so that rsyslog can run as user.
+# See tmpfiles.d(5) for details.
+
+# Type Path    Mode UID  GID  Age Argument
+z /var/log 0775 root syslog -
+z /var/log/auth.log 0640 syslog adm -
+z /var/log/mail.err 0640 syslog adm -
+z /var/log/mail.log 0640 syslog adm -
+z /var/log/kern.log 0640 syslog adm -
+z /var/log/syslog 0640 syslog adm -
+d /var/spool/rsyslog 0700 syslog adm -

--- a/rsyslog/cosmic/v8-stable/debian/rsyslog.install
+++ b/rsyslog/cosmic/v8-stable/debian/rsyslog.install
@@ -1,4 +1,5 @@
 debian/rsyslog.conf /etc/
+debian/00rsyslog.conf  usr/lib/tmpfiles.d/
 debian/50-default.conf /usr/share/rsyslog
 debian/tmp/usr/sbin/
 debian/tmp/usr/share/man/

--- a/rsyslog/disco/master/debian/00rsyslog.conf
+++ b/rsyslog/disco/master/debian/00rsyslog.conf
@@ -1,0 +1,12 @@
+# Override systemd's default tmpfiles.d/var.conf to make /var/log writable by
+# the syslog group, so that rsyslog can run as user.
+# See tmpfiles.d(5) for details.
+
+# Type Path    Mode UID  GID  Age Argument
+z /var/log 0775 root syslog -
+z /var/log/auth.log 0640 syslog adm -
+z /var/log/mail.err 0640 syslog adm -
+z /var/log/mail.log 0640 syslog adm -
+z /var/log/kern.log 0640 syslog adm -
+z /var/log/syslog 0640 syslog adm -
+d /var/spool/rsyslog 0700 syslog adm -

--- a/rsyslog/disco/master/debian/rsyslog.install
+++ b/rsyslog/disco/master/debian/rsyslog.install
@@ -1,4 +1,5 @@
 debian/rsyslog.conf /etc/
+debian/00rsyslog.conf  usr/lib/tmpfiles.d/
 debian/50-default.conf /usr/share/rsyslog
 debian/tmp/usr/sbin/
 debian/tmp/usr/share/man/

--- a/rsyslog/disco/v8-stable/debian/00rsyslog.conf
+++ b/rsyslog/disco/v8-stable/debian/00rsyslog.conf
@@ -1,0 +1,12 @@
+# Override systemd's default tmpfiles.d/var.conf to make /var/log writable by
+# the syslog group, so that rsyslog can run as user.
+# See tmpfiles.d(5) for details.
+
+# Type Path    Mode UID  GID  Age Argument
+z /var/log 0775 root syslog -
+z /var/log/auth.log 0640 syslog adm -
+z /var/log/mail.err 0640 syslog adm -
+z /var/log/mail.log 0640 syslog adm -
+z /var/log/kern.log 0640 syslog adm -
+z /var/log/syslog 0640 syslog adm -
+d /var/spool/rsyslog 0700 syslog adm -

--- a/rsyslog/disco/v8-stable/debian/rsyslog.install
+++ b/rsyslog/disco/v8-stable/debian/rsyslog.install
@@ -1,4 +1,5 @@
 debian/rsyslog.conf /etc/
+debian/00rsyslog.conf  usr/lib/tmpfiles.d/
 debian/50-default.conf /usr/share/rsyslog
 debian/tmp/usr/sbin/
 debian/tmp/usr/share/man/

--- a/rsyslog/eoan/master/debian/00rsyslog.conf
+++ b/rsyslog/eoan/master/debian/00rsyslog.conf
@@ -1,0 +1,12 @@
+# Override systemd's default tmpfiles.d/var.conf to make /var/log writable by
+# the syslog group, so that rsyslog can run as user.
+# See tmpfiles.d(5) for details.
+
+# Type Path    Mode UID  GID  Age Argument
+z /var/log 0775 root syslog -
+z /var/log/auth.log 0640 syslog adm -
+z /var/log/mail.err 0640 syslog adm -
+z /var/log/mail.log 0640 syslog adm -
+z /var/log/kern.log 0640 syslog adm -
+z /var/log/syslog 0640 syslog adm -
+d /var/spool/rsyslog 0700 syslog adm -

--- a/rsyslog/eoan/master/debian/rsyslog.install
+++ b/rsyslog/eoan/master/debian/rsyslog.install
@@ -1,4 +1,5 @@
 debian/rsyslog.conf /etc/
+debian/00rsyslog.conf  usr/lib/tmpfiles.d/
 debian/50-default.conf /usr/share/rsyslog
 debian/tmp/usr/sbin/
 debian/tmp/usr/share/man/

--- a/rsyslog/eoan/v8-stable/debian/00rsyslog.conf
+++ b/rsyslog/eoan/v8-stable/debian/00rsyslog.conf
@@ -1,0 +1,12 @@
+# Override systemd's default tmpfiles.d/var.conf to make /var/log writable by
+# the syslog group, so that rsyslog can run as user.
+# See tmpfiles.d(5) for details.
+
+# Type Path    Mode UID  GID  Age Argument
+z /var/log 0775 root syslog -
+z /var/log/auth.log 0640 syslog adm -
+z /var/log/mail.err 0640 syslog adm -
+z /var/log/mail.log 0640 syslog adm -
+z /var/log/kern.log 0640 syslog adm -
+z /var/log/syslog 0640 syslog adm -
+d /var/spool/rsyslog 0700 syslog adm -

--- a/rsyslog/eoan/v8-stable/debian/rsyslog.install
+++ b/rsyslog/eoan/v8-stable/debian/rsyslog.install
@@ -1,4 +1,5 @@
 debian/rsyslog.conf /etc/
+debian/00rsyslog.conf  usr/lib/tmpfiles.d/
 debian/50-default.conf /usr/share/rsyslog
 debian/tmp/usr/sbin/
 debian/tmp/usr/share/man/

--- a/rsyslog/xenial/master/debian/00rsyslog.conf
+++ b/rsyslog/xenial/master/debian/00rsyslog.conf
@@ -1,0 +1,12 @@
+# Override systemd's default tmpfiles.d/var.conf to make /var/log writable by
+# the syslog group, so that rsyslog can run as user.
+# See tmpfiles.d(5) for details.
+
+# Type Path    Mode UID  GID  Age Argument
+z /var/log 0775 root syslog -
+z /var/log/auth.log 0640 syslog adm -
+z /var/log/mail.err 0640 syslog adm -
+z /var/log/mail.log 0640 syslog adm -
+z /var/log/kern.log 0640 syslog adm -
+z /var/log/syslog 0640 syslog adm -
+d /var/spool/rsyslog 0700 syslog adm -

--- a/rsyslog/xenial/master/debian/rsyslog.install
+++ b/rsyslog/xenial/master/debian/rsyslog.install
@@ -1,4 +1,5 @@
 debian/rsyslog.conf /etc/
+debian/00rsyslog.conf  usr/lib/tmpfiles.d/
 debian/50-default.conf /usr/share/rsyslog
 debian/tmp/usr/sbin/
 debian/tmp/usr/share/man/

--- a/rsyslog/xenial/v8-stable/debian/00rsyslog.conf
+++ b/rsyslog/xenial/v8-stable/debian/00rsyslog.conf
@@ -1,0 +1,12 @@
+# Override systemd's default tmpfiles.d/var.conf to make /var/log writable by
+# the syslog group, so that rsyslog can run as user.
+# See tmpfiles.d(5) for details.
+
+# Type Path    Mode UID  GID  Age Argument
+z /var/log 0775 root syslog -
+z /var/log/auth.log 0640 syslog adm -
+z /var/log/mail.err 0640 syslog adm -
+z /var/log/mail.log 0640 syslog adm -
+z /var/log/kern.log 0640 syslog adm -
+z /var/log/syslog 0640 syslog adm -
+d /var/spool/rsyslog 0700 syslog adm -

--- a/rsyslog/xenial/v8-stable/debian/rsyslog.install
+++ b/rsyslog/xenial/v8-stable/debian/rsyslog.install
@@ -1,4 +1,5 @@
 debian/rsyslog.conf /etc/
+debian/00rsyslog.conf  usr/lib/tmpfiles.d/
 debian/50-default.conf /usr/share/rsyslog
 debian/tmp/usr/sbin/
 debian/tmp/usr/share/man/

--- a/rsyslog/yakkety/master/debian/00rsyslog.conf
+++ b/rsyslog/yakkety/master/debian/00rsyslog.conf
@@ -1,0 +1,12 @@
+# Override systemd's default tmpfiles.d/var.conf to make /var/log writable by
+# the syslog group, so that rsyslog can run as user.
+# See tmpfiles.d(5) for details.
+
+# Type Path    Mode UID  GID  Age Argument
+z /var/log 0775 root syslog -
+z /var/log/auth.log 0640 syslog adm -
+z /var/log/mail.err 0640 syslog adm -
+z /var/log/mail.log 0640 syslog adm -
+z /var/log/kern.log 0640 syslog adm -
+z /var/log/syslog 0640 syslog adm -
+d /var/spool/rsyslog 0700 syslog adm -

--- a/rsyslog/yakkety/master/debian/rsyslog.install
+++ b/rsyslog/yakkety/master/debian/rsyslog.install
@@ -1,4 +1,5 @@
 debian/rsyslog.conf /etc/
+debian/00rsyslog.conf  usr/lib/tmpfiles.d/
 debian/50-default.conf /usr/share/rsyslog
 debian/tmp/usr/sbin/
 debian/tmp/usr/share/man/

--- a/rsyslog/yakkety/v8-stable/debian/00rsyslog.conf
+++ b/rsyslog/yakkety/v8-stable/debian/00rsyslog.conf
@@ -1,0 +1,12 @@
+# Override systemd's default tmpfiles.d/var.conf to make /var/log writable by
+# the syslog group, so that rsyslog can run as user.
+# See tmpfiles.d(5) for details.
+
+# Type Path    Mode UID  GID  Age Argument
+z /var/log 0775 root syslog -
+z /var/log/auth.log 0640 syslog adm -
+z /var/log/mail.err 0640 syslog adm -
+z /var/log/mail.log 0640 syslog adm -
+z /var/log/kern.log 0640 syslog adm -
+z /var/log/syslog 0640 syslog adm -
+d /var/spool/rsyslog 0700 syslog adm -

--- a/rsyslog/yakkety/v8-stable/debian/rsyslog.install
+++ b/rsyslog/yakkety/v8-stable/debian/rsyslog.install
@@ -1,4 +1,5 @@
 debian/rsyslog.conf /etc/
+debian/00rsyslog.conf  usr/lib/tmpfiles.d/
 debian/50-default.conf /usr/share/rsyslog
 debian/tmp/usr/sbin/
 debian/tmp/usr/share/man/

--- a/rsyslog/zesty/master/debian/00rsyslog.conf
+++ b/rsyslog/zesty/master/debian/00rsyslog.conf
@@ -1,0 +1,12 @@
+# Override systemd's default tmpfiles.d/var.conf to make /var/log writable by
+# the syslog group, so that rsyslog can run as user.
+# See tmpfiles.d(5) for details.
+
+# Type Path    Mode UID  GID  Age Argument
+z /var/log 0775 root syslog -
+z /var/log/auth.log 0640 syslog adm -
+z /var/log/mail.err 0640 syslog adm -
+z /var/log/mail.log 0640 syslog adm -
+z /var/log/kern.log 0640 syslog adm -
+z /var/log/syslog 0640 syslog adm -
+d /var/spool/rsyslog 0700 syslog adm -

--- a/rsyslog/zesty/master/debian/rsyslog.install
+++ b/rsyslog/zesty/master/debian/rsyslog.install
@@ -1,4 +1,5 @@
 debian/rsyslog.conf /etc/
+debian/00rsyslog.conf  usr/lib/tmpfiles.d/
 debian/50-default.conf /usr/share/rsyslog
 debian/tmp/usr/sbin/
 debian/tmp/usr/share/man/

--- a/rsyslog/zesty/v8-stable/debian/00rsyslog.conf
+++ b/rsyslog/zesty/v8-stable/debian/00rsyslog.conf
@@ -1,0 +1,12 @@
+# Override systemd's default tmpfiles.d/var.conf to make /var/log writable by
+# the syslog group, so that rsyslog can run as user.
+# See tmpfiles.d(5) for details.
+
+# Type Path    Mode UID  GID  Age Argument
+z /var/log 0775 root syslog -
+z /var/log/auth.log 0640 syslog adm -
+z /var/log/mail.err 0640 syslog adm -
+z /var/log/mail.log 0640 syslog adm -
+z /var/log/kern.log 0640 syslog adm -
+z /var/log/syslog 0640 syslog adm -
+d /var/spool/rsyslog 0700 syslog adm -

--- a/rsyslog/zesty/v8-stable/debian/rsyslog.install
+++ b/rsyslog/zesty/v8-stable/debian/rsyslog.install
@@ -1,4 +1,5 @@
 debian/rsyslog.conf /etc/
+debian/00rsyslog.conf  usr/lib/tmpfiles.d/
 debian/50-default.conf /usr/share/rsyslog
 debian/tmp/usr/sbin/
 debian/tmp/usr/share/man/


### PR DESCRIPTION
Override systemd's default `tmpfiles.d/var.conf` to make `/var/log` writable by the syslog group, so that rsyslog can run as user.
The config file was copied from the upstream Ubuntu package, and added to the Ubuntu distro versions that default to systemd (`xenial` onwards).

Fixes #61.

I haven't tested/verified this works at all, I'll leave that to a maintainer more familiar with the process for this project. Hoping this PR will help move along a fix for this issue!