### PR TITLE
Add GitHub Actions Workflow to test pkg installs

### DIFF
--- a/.github/workflows/install-rsyslog-packages-from-obs.yml
+++ b/.github/workflows/install-rsyslog-packages-from-obs.yml
@@ -1,0 +1,152 @@
+# Copyright 2020 Rainer Gerhards and Others
+#
+# https://github.com/rsyslog/rsyslog-pkg-ubuntu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# References:
+#
+# https://help.github.com/en/github/managing-subscriptions-and-notifications-on-github/configuring-notifications#github-actions-notification-options
+# https://github.com/settings/notifications
+# https://software.opensuse.org//download.html?project=home%3Argerhards&package=rsyslog
+
+---
+name: Install rsyslog packages from OBS
+
+on:
+  schedule:
+    # Example of job definition:
+    # .---------------- minute (0 - 59)
+    # |  .------------- hour (0 - 23)
+    # |  |  .---------- day of month (1 - 31)
+    # |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+    # |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
+    # |  |  |  |  |
+    # *  *  *  *  *
+
+    # Run daily
+    - cron: "15 0 * * *"
+    #
+    # Run every 4 hours
+    #- cron: "0 0,4,8,12,16,20 * * *"
+    #
+    # Run every hour (relaxed testing purposes)
+    #- cron: "0 * * * *"
+    #
+    # Run once every 15 minutes (good for testing changes)
+    #- cron: "*/15 * * * *"
+
+jobs:
+  enable_obs_repo_and_install_packages:
+    name: Enable OBS repo and install packages
+    runs-on: ${{ matrix.os }}
+    # Default: 360 minutes
+    timeout-minutes: 10
+    strategy:
+      # When set to true, cancel all in-progress jobs if any matrix job fails.
+      fail-fast: false
+      matrix:
+        # Explicitly list supported LTS versions
+        # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
+        # Note: As of 2020-06 ubuntu-latest' maps to 'ubuntu-18.04', not ubuntu-20.04
+        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+
+    steps:
+      - name: Install stock Ubuntu-provided rsyslog
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rsyslog
+
+      - name: Display stock Ubuntu-provided rsyslog version
+        run: rsyslogd -v
+
+      - name: Show apt-cache policy rsyslog results before adding OBS
+        run: sudo apt-cache policy rsyslog
+
+      - name: Search APT cache for rsyslog before adding OBS
+        run: apt-cache search rsyslog
+
+      - name: Show records for rsyslog-prefixed packages before adding OBS
+        run: apt-cache showpkg "rsyslog*"
+
+      - name: Add OBS
+        run: |
+          echo "deb http://download.opensuse.org/repositories/home:/rgerhards/xUbuntu_$(lsb_release -r | cut -f 2)/ /" | sudo tee /etc/apt/sources.list.d/home:rgerhards.list
+          wget -nv https://download.opensuse.org/repositories/home:rgerhards/xUbuntu_$(lsb_release -r | cut -f 2)/Release.key -O - | sudo apt-key add -
+          sudo apt update
+
+      - name: Show apt-cache policy rsyslog results after adding OBS
+        run: sudo apt-cache policy rsyslog
+
+      - name: Search APT cache for rsyslog after adding OBS
+        run: apt-cache search rsyslog
+
+      - name: Show records for rsyslog-prefixed packages after adding OBS
+        run: apt-cache showpkg "rsyslog*"
+
+      - name: Install core rsyslog package
+        run: sudo apt-get install -y rsyslog
+
+      - name: Display OBS-provided rsyslog version
+        run: rsyslogd -v
+
+      - name: Restart rsyslog
+        run: sudo service rsyslog restart
+
+      - name: systemctl status output
+        run: sudo systemctl status rsyslog
+
+      - name: Install rsyslog-kafka
+        run: sudo apt-get install rsyslog-kafka
+
+      - name: Install rsyslog-doc
+        run: sudo apt-get install rsyslog-doc
+
+      - name: Install rsyslog-relp
+        run: sudo apt-get install rsyslog-relp
+
+      - name: Install rsyslog-elasticsearch
+        run: sudo apt-get install rsyslog-elasticsearch
+
+      - name: Install rsyslog-imptcp
+        run: sudo apt-get install rsyslog-imptcp
+
+      - name: Install rsyslog-mmnormalize
+        run: sudo apt-get install rsyslog-mmnormalize
+
+      - name: Install rsyslog-mmanon
+        run: sudo apt-get install rsyslog-mmanon
+
+      - name: Install rsyslog-mmfields
+        run: sudo apt-get install rsyslog-mmfields
+
+      - name: Install rsyslog-mmutf8fix
+        run: sudo apt-get install rsyslog-mmutf8fix
+
+      - name: Install rsyslog-utils
+        run: sudo apt-get install rsyslog-utils
+
+      - name: Install rsyslog-mmrm1stspace
+        run: sudo apt-get install rsyslog-mmrm1stspace
+
+      - name: Install rsyslog-pgsql
+        run: sudo apt-get install rsyslog-pgsql
+
+      - name: Install rsyslog-mysql
+        run: sudo apt-get install rsyslog-mysql
+
+      - name: Install rsyslog-mmjsonparse
+        run: sudo apt-get install rsyslog-mmjsonparse
+
+      - name: Display installed rsyslog packages
+        run: dpkg -l | grep -E 'rsyslog|adiscon'

--- a/.github/workflows/install-rsyslog-packages-from-ppa.yml
+++ b/.github/workflows/install-rsyslog-packages-from-ppa.yml
@@ -1,0 +1,259 @@
+# Copyright 2020 Rainer Gerhards and Others
+#
+# https://github.com/rsyslog/rsyslog-pkg-ubuntu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# References:
+#
+# https://help.github.com/en/github/managing-subscriptions-and-notifications-on-github/configuring-notifications#github-actions-notification-options
+# https://github.com/settings/notifications
+# https://www.rsyslog.com/ubuntu-repository/
+
+---
+name: Install rsyslog packages from PPA
+
+on:
+  schedule:
+    # Example of job definition:
+    # .---------------- minute (0 - 59)
+    # |  .------------- hour (0 - 23)
+    # |  |  .---------- day of month (1 - 31)
+    # |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+    # |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
+    # |  |  |  |  |
+    # *  *  *  *  *
+
+    # Run daily
+    - cron: "15 0 * * *"
+    #
+    # Run every 4 hours
+    #- cron: "0 0,4,8,12,16,20 * * *"
+    #
+    # Run every hour (relaxed testing purposes)
+    #- cron: "0 * * * *"
+    #
+    # Run once every 15 minutes (good for testing changes)
+    #- cron: "*/15 * * * *"
+
+jobs:
+  enable_scheduled_stable_ppa_and_install_packages:
+    name: Enable scheduled stable PPA and install packages
+    runs-on: ${{ matrix.os }}
+    # Default: 360 minutes
+    timeout-minutes: 10
+    strategy:
+      # When set to true, cancel all in-progress jobs if any matrix job fails.
+      fail-fast: false
+      matrix:
+        # Explicitly list supported LTS versions
+        # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
+        # Note: 'ubuntu-latest' currently maps to 'ubuntu-18.04'
+        #os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, ubuntu-latest]
+        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+
+    steps:
+      - name: Install stock Ubuntu-provided rsyslog
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rsyslog
+
+      - name: Display stock Ubuntu-provided rsyslog version
+        run: rsyslogd -v
+
+      - name: Show apt-cache policy rsyslog results before adding PPA
+        run: sudo apt-cache policy rsyslog
+
+      - name: Search APT cache for rsyslog before adding PPA
+        run: apt-cache search rsyslog
+
+      - name: Show records for rsyslog-prefixed packages before adding PPA
+        run: apt-cache showpkg "rsyslog*"
+
+      - name: Add PPA
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes software-properties-common
+          sudo add-apt-repository --yes --update ppa:adiscon/v8-stable
+          sudo apt-get update
+
+      - name: Show apt-cache policy rsyslog results after adding PPA
+        run: sudo apt-cache policy rsyslog
+
+      - name: Search APT cache for rsyslog after adding PPA
+        run: apt-cache search rsyslog
+
+      - name: Show records for rsyslog-prefixed packages after adding PPA
+        run: apt-cache showpkg "rsyslog*"
+
+      - name: Install core rsyslog package
+        run: sudo apt-get install -y rsyslog
+
+      - name: Display PPA-provided rsyslog version
+        run: rsyslogd -v
+
+      - name: Restart rsyslog
+        run: sudo service rsyslog restart
+
+      - name: systemctl status output
+        run: sudo systemctl status rsyslog
+
+      - name: Install rsyslog-kafka
+        run: sudo apt-get install rsyslog-kafka
+
+      - name: Install rsyslog-doc
+        run: sudo apt-get install rsyslog-doc
+
+      - name: Install rsyslog-relp
+        run: sudo apt-get install rsyslog-relp
+
+      - name: Install rsyslog-elasticsearch
+        run: sudo apt-get install rsyslog-elasticsearch
+
+      - name: Install rsyslog-imptcp
+        run: sudo apt-get install rsyslog-imptcp
+
+      - name: Install rsyslog-mmnormalize
+        run: sudo apt-get install rsyslog-mmnormalize
+
+      - name: Install rsyslog-mmanon
+        run: sudo apt-get install rsyslog-mmanon
+
+      - name: Install rsyslog-mmfields
+        run: sudo apt-get install rsyslog-mmfields
+
+      - name: Install rsyslog-mmutf8fix
+        run: sudo apt-get install rsyslog-mmutf8fix
+
+      - name: Install rsyslog-utils
+        run: sudo apt-get install rsyslog-utils
+
+      - name: Install rsyslog-mmrm1stspace
+        run: sudo apt-get install rsyslog-mmrm1stspace
+
+      - name: Install rsyslog-pgsql
+        run: sudo apt-get install rsyslog-pgsql
+
+      - name: Install rsyslog-mysql
+        run: sudo apt-get install rsyslog-mysql
+
+      - name: Install rsyslog-mmjsonparse
+        run: sudo apt-get install rsyslog-mmjsonparse
+
+      - name: Display installed rsyslog packages
+        run: dpkg -l | grep -E 'rsyslog|adiscon'
+
+  enable_daily_stable_ppa_and_install_packages:
+    name: Enable daily stable PPA and install packages
+    runs-on: ${{ matrix.os }}
+    # Default: 360 minutes
+    timeout-minutes: 10
+    strategy:
+      # When set to true, cancel all in-progress jobs if any matrix job fails.
+      fail-fast: false
+      matrix:
+        # Explicitly list supported LTS versions
+        # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
+        # Note: 'ubuntu-latest' currently maps to 'ubuntu-18.04'
+        #os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, ubuntu-latest]
+        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+
+    steps:
+      - name: Install stock Ubuntu-provided rsyslog
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rsyslog
+
+      - name: Display stock Ubuntu-provided rsyslog version
+        run: rsyslogd -v
+
+      - name: Show apt-cache policy rsyslog results before adding PPA
+        run: sudo apt-cache policy rsyslog
+
+      - name: Search APT cache for rsyslog before adding PPA
+        run: apt-cache search rsyslog
+
+      - name: Show records for rsyslog-prefixed packages before adding PPA
+        run: apt-cache showpkg "rsyslog*"
+
+      - name: Add PPA
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes software-properties-common
+          sudo add-apt-repository --yes --update ppa:adiscon/v8-devel
+
+      - name: Show apt-cache policy rsyslog results after adding PPA
+        run: sudo apt-cache policy rsyslog
+
+      - name: Search APT cache for rsyslog after adding PPA
+        run: apt-cache search rsyslog
+
+      - name: Show records for rsyslog-prefixed packages after adding PPA
+        run: apt-cache showpkg "rsyslog*"
+
+      - name: Install core rsyslog package
+        run: sudo apt-get install -y rsyslog
+
+      - name: Display PPA-provided rsyslog version
+        run: rsyslogd -v
+
+      - name: Restart rsyslog
+        run: sudo service rsyslog restart
+
+      - name: systemctl status output
+        run: sudo systemctl status rsyslog
+
+      - name: Install rsyslog-kafka
+        run: sudo apt-get install rsyslog-kafka
+
+      - name: Install rsyslog-doc
+        run: sudo apt-get install rsyslog-doc
+
+      - name: Install rsyslog-relp
+        run: sudo apt-get install rsyslog-relp
+
+      - name: Install rsyslog-elasticsearch
+        run: sudo apt-get install rsyslog-elasticsearch
+
+      - name: Install rsyslog-imptcp
+        run: sudo apt-get install rsyslog-imptcp
+
+      - name: Install rsyslog-mmnormalize
+        run: sudo apt-get install rsyslog-mmnormalize
+
+      - name: Install rsyslog-mmanon
+        run: sudo apt-get install rsyslog-mmanon
+
+      - name: Install rsyslog-mmfields
+        run: sudo apt-get install rsyslog-mmfields
+
+      - name: Install rsyslog-mmutf8fix
+        run: sudo apt-get install rsyslog-mmutf8fix
+
+      - name: Install rsyslog-utils
+        run: sudo apt-get install rsyslog-utils
+
+      - name: Install rsyslog-mmrm1stspace
+        run: sudo apt-get install rsyslog-mmrm1stspace
+
+      - name: Install rsyslog-pgsql
+        run: sudo apt-get install rsyslog-pgsql
+
+      - name: Install rsyslog-mysql
+        run: sudo apt-get install rsyslog-mysql
+
+      - name: Install rsyslog-mmjsonparse
+        run: sudo apt-get install rsyslog-mmjsonparse
+
+      - name: Display installed rsyslog packages
+        run: dpkg -l | grep -E 'rsyslog|adiscon'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 rsyslog-pkg-ubuntu
 ==================
 
+<!--
+  FIXME: Reference the upstream repo instead of this forked/testing repo when submitting upstream
+ -->
+![Install rsyslog packages from OBS](https://github.com/atc0005/rsyslog-pkg-ubuntu/workflows/Install%20rsyslog%20packages%20from%20OBS/badge.svg?branch=master)
+![Install rsyslog packages from PPA](https://github.com/atc0005/rsyslog-pkg-ubuntu/workflows/Install%20rsyslog%20packages%20from%20PPA/badge.svg)
+
+
 This respository contains the sources needed to build Ubuntu rsyslog
 packages. It is our goal to create the best possible packages for
 the current releases of this platform.


### PR DESCRIPTION
## CHANGES

The Workflows provided by this Pull Request perform the following
actions on a daily schedule:

- Install stock Ubuntu rsyslog

- Enable official "upstream" repo, install upstream rsyslog

- Install additional upstream rsyslog packages as separate steps to
  help isolate potential installation issues

Other output captured:

- rsyslog packages and cache info
- systemctl status output
- dpkg -l output filtered to rsyslog, adiscon
- 'apt-cache policy rsyslog' results before and after adding PPA

These tasks are performed on these Ubuntu releases:

- Ubuntu 16.04
- Ubuntu 18.04
- Ubuntu 20.04

This process is performed for:

- "daily stable" PPA
- "scheduled stable" PPA
- Open Build Service (OBS) repo

The main README has been updated to provide status badges to quickly
display the status of the latest workflow job executions.

## REFERENCES

- rsyslog/rsyslog-pkg-ubuntu#69
- atc0005/rsyslog-pkg-ubuntu#1