### PR TITLE
add omuxsock to base package

### DIFF
--- a/rsyslog/bionic/v8-stable/debian/changelog
+++ b/rsyslog/bionic/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.2006.0-0adiscon2bionic1) bionic; urgency=medium
+
+  * Packages for 8.2006.0
+
+ -- Rainer Gerhards <adiscon-pkg-maintainers@adiscon.com>  Mon, 06 Jul 2020 09:24:57 +0000
+
 rsyslog (8.2006.0-0adiscon1bionic1) bionic; urgency=medium
 
   * Packages for 8.2006.0

--- a/rsyslog/bionic/v8-stable/debian/rsyslog.install
+++ b/rsyslog/bionic/v8-stable/debian/rsyslog.install
@@ -9,6 +9,7 @@ debian/tmp/usr/lib/rsyslog/impstats.so
 debian/tmp/usr/lib/rsyslog/imtcp.so
 debian/tmp/usr/lib/rsyslog/imudp.so
 debian/tmp/usr/lib/rsyslog/imuxsock.so
+debian/tmp/usr/lib/rsyslog/omuxsock.so
 debian/tmp/usr/lib/rsyslog/imjournal.so
 debian/tmp/usr/lib/rsyslog/lmnet.so
 debian/tmp/usr/lib/rsyslog/lmnetstrms.so

--- a/rsyslog/bionic/v8-stable/debian/rules
+++ b/rsyslog/bionic/v8-stable/debian/rules
@@ -14,6 +14,7 @@ unexport LDFLAGS
 override_dh_auto_configure:
 	dh_auto_configure -- \
 		--enable-kmsg \
+		--enable-omuxsock \
 		--enable-mysql \
 		--enable-pgsql \
 		--enable-mail \

--- a/rsyslog/eoan/v8-stable/debian/rsyslog.install
+++ b/rsyslog/eoan/v8-stable/debian/rsyslog.install
@@ -9,6 +9,7 @@ debian/tmp/usr/lib/rsyslog/impstats.so
 debian/tmp/usr/lib/rsyslog/imtcp.so
 debian/tmp/usr/lib/rsyslog/imudp.so
 debian/tmp/usr/lib/rsyslog/imuxsock.so
+debian/tmp/usr/lib/rsyslog/omuxsock.so
 debian/tmp/usr/lib/rsyslog/imjournal.so
 debian/tmp/usr/lib/rsyslog/lmnet.so
 debian/tmp/usr/lib/rsyslog/lmnetstrms.so

--- a/rsyslog/eoan/v8-stable/debian/rules
+++ b/rsyslog/eoan/v8-stable/debian/rules
@@ -14,6 +14,7 @@ unexport LDFLAGS
 override_dh_auto_configure:
 	dh_auto_configure -- \
 		--enable-kmsg \
+		--enable-omuxsock \
 		--enable-mysql \
 		--enable-pgsql \
 		--enable-mail \

--- a/rsyslog/focal/v8-stable/debian/rsyslog.install
+++ b/rsyslog/focal/v8-stable/debian/rsyslog.install
@@ -9,6 +9,7 @@ debian/tmp/usr/lib/rsyslog/impstats.so
 debian/tmp/usr/lib/rsyslog/imtcp.so
 debian/tmp/usr/lib/rsyslog/imudp.so
 debian/tmp/usr/lib/rsyslog/imuxsock.so
+debian/tmp/usr/lib/rsyslog/omuxsock.so
 debian/tmp/usr/lib/rsyslog/imjournal.so
 debian/tmp/usr/lib/rsyslog/lmnet.so
 debian/tmp/usr/lib/rsyslog/lmnetstrms.so

--- a/rsyslog/focal/v8-stable/debian/rules
+++ b/rsyslog/focal/v8-stable/debian/rules
@@ -16,6 +16,7 @@ override_dh_auto_configure:
 		--libexecdir=/usr/lib/rsyslog \
 		--libdir=/usr/lib \
 		--enable-kmsg \
+		--enable-omuxsock \
 		--enable-mysql \
 		--enable-pgsql \
 		--enable-mail \

--- a/rsyslog/groovy/v8-stable/debian/rsyslog.install
+++ b/rsyslog/groovy/v8-stable/debian/rsyslog.install
@@ -9,6 +9,7 @@ debian/tmp/usr/lib/rsyslog/impstats.so
 debian/tmp/usr/lib/rsyslog/imtcp.so
 debian/tmp/usr/lib/rsyslog/imudp.so
 debian/tmp/usr/lib/rsyslog/imuxsock.so
+debian/tmp/usr/lib/rsyslog/omuxsock.so
 debian/tmp/usr/lib/rsyslog/imjournal.so
 debian/tmp/usr/lib/rsyslog/lmnet.so
 debian/tmp/usr/lib/rsyslog/lmnetstrms.so

--- a/rsyslog/groovy/v8-stable/debian/rules
+++ b/rsyslog/groovy/v8-stable/debian/rules
@@ -42,6 +42,7 @@ override_dh_auto_configure:
 		--enable-pmnormalize \
 		--enable-usertools \
 		--enable-kmsg \
+		--enable-omuxsock \
 		--enable-imjournal \
 		--enable-omjournal \
 		--enable-mmrm1stspace \

--- a/rsyslog/trusty/v8-stable/debian/rsyslog.install
+++ b/rsyslog/trusty/v8-stable/debian/rsyslog.install
@@ -9,6 +9,7 @@ debian/tmp/usr/lib/rsyslog/impstats.so
 debian/tmp/usr/lib/rsyslog/imtcp.so
 debian/tmp/usr/lib/rsyslog/imudp.so
 debian/tmp/usr/lib/rsyslog/imuxsock.so
+debian/tmp/usr/lib/rsyslog/omuxsock.so
 debian/tmp/usr/lib/rsyslog/lmnet.so
 debian/tmp/usr/lib/rsyslog/lmnetstrms.so
 debian/tmp/usr/lib/rsyslog/lmnsd_ptcp.so

--- a/rsyslog/trusty/v8-stable/debian/rules
+++ b/rsyslog/trusty/v8-stable/debian/rules
@@ -16,6 +16,7 @@ unexport LDFLAGS
 override_dh_auto_configure:
 	dh_auto_configure -- \
 		--enable-kmsg \
+		--enable-omuxsock \
 		--enable-mysql \
 		--enable-pgsql \
 		--enable-mail \

--- a/rsyslog/xenial/v8-stable/debian/debian/rsyslog.install
+++ b/rsyslog/xenial/v8-stable/debian/debian/rsyslog.install
@@ -9,6 +9,7 @@ debian/tmp/usr/lib/rsyslog/impstats.so
 debian/tmp/usr/lib/rsyslog/imtcp.so
 debian/tmp/usr/lib/rsyslog/imudp.so
 debian/tmp/usr/lib/rsyslog/imuxsock.so
+debian/tmp/usr/lib/rsyslog/omuxsock.so
 debian/tmp/usr/lib/rsyslog/imjournal.so
 debian/tmp/usr/lib/rsyslog/lmnet.so
 debian/tmp/usr/lib/rsyslog/lmnetstrms.so

--- a/rsyslog/xenial/v8-stable/debian/rsyslog.install
+++ b/rsyslog/xenial/v8-stable/debian/rsyslog.install
@@ -9,6 +9,7 @@ debian/tmp/usr/lib/rsyslog/impstats.so
 debian/tmp/usr/lib/rsyslog/imtcp.so
 debian/tmp/usr/lib/rsyslog/imudp.so
 debian/tmp/usr/lib/rsyslog/imuxsock.so
+debian/tmp/usr/lib/rsyslog/omuxsock.so
 debian/tmp/usr/lib/rsyslog/imjournal.so
 debian/tmp/usr/lib/rsyslog/lmnet.so
 debian/tmp/usr/lib/rsyslog/lmnetstrms.so

--- a/rsyslog/xenial/v8-stable/debian/rules
+++ b/rsyslog/xenial/v8-stable/debian/rules
@@ -14,6 +14,7 @@ unexport LDFLAGS
 override_dh_auto_configure:
 	dh_auto_configure -- \
 		--enable-kmsg \
+		--enable-omuxsock \
 		--enable-mysql \
 		--enable-pgsql \
 		--enable-mail \


### PR DESCRIPTION
omuxsock was not yet packaged at all, but is at least in newer
Ubuntu default packages

closes https://github.com/rsyslog/rsyslog-pkg-ubuntu/issues/98