### PR TITLE
bump definitions for 8.2010 upstream release (in regard to OBS)

### DIFF
--- a/rsyslog/Debian/v8-stable/debian/changelog
+++ b/rsyslog/Debian/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.2010.0-1) xenial; urgency=medium
+
+  * new upstream release
+
+ -- Rainer Gerhards <rgerhards@adiscon.com> Tue, 20 Oct 2020 13:16:00 +0000
+
 rsyslog (8.2008.0-1) xenial; urgency=medium
 
   * new upstream release

--- a/rsyslog/bionic/v8-stable/debian/changelog
+++ b/rsyslog/bionic/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.2010.0-0adiscon1bionic1) bionic; urgency=medium
+
+  * Packages for 8.2010.0
+
+ -- Rainer Gerhards <adiscon-pkg-maintainers@adiscon.com>  Tue, 10 Oct 2020 09:24:57 +0000
+
 rsyslog (8.2008.0-0adiscon1bionic1) bionic; urgency=medium
 
   * Packages for 8.2008.0

--- a/rsyslog/editfile.sh
+++ b/rsyslog/editfile.sh
@@ -1,1 +1,6 @@
-vi $(find . -name $1 | grep v8-st|grep -v Deb)
+vi $(find . -name $1 | grep v8-st)
+# use the following if you do NOT want to edit the generic
+# Debian definitions; note: Debian packages for all versions are
+# build with these definitions and the changelog must be updated on
+# a new upstream release
+#vi $(find . -name $1 | grep v8-st|grep -v Deb)

--- a/rsyslog/eoan/v8-stable/debian/changelog
+++ b/rsyslog/eoan/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.2010.0-0adiscon1eoan1) eoan; urgency=medium
+
+  * Packages for 8.2010.0
+
+ -- Rainer Gerhards <adiscon-pkg-maintainers@adiscon.com>  Tue, 10 Oct 2020 09:24:57 +0000
+
 rsyslog (8.2008.0-0adiscon1eoan1) eoan; urgency=medium
 
   * Packages for 8.2008.0

--- a/rsyslog/focal/v8-stable/debian/changelog
+++ b/rsyslog/focal/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.2010.0-0adiscon1focal1) focal; urgency=medium
+
+  * Packages for 8.2010.0
+
+ -- Rainer Gerhards <rgerhards@adiscon.com>  Tue, 10 Oct 2020 09:24:57 +0000
+
 rsyslog (8.2008.0-0adiscon1focal1) focal; urgency=medium
 
   * Packages for 8.2008.0

--- a/rsyslog/groovy/v8-stable/debian/changelog
+++ b/rsyslog/groovy/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.2010.0-0adiscon1groovy1) groovy; urgency=medium
+
+  * Packages for 8.2010.0
+
+ -- Rainer Gerhards <rgerhards@adiscon.com>  Tue, 10 Oct 2020 09:24:57 +0000
+
 rsyslog (8.2008.0-0adiscon1groovy1) groovy; urgency=medium
 
   * Packages for 8.2008.0

--- a/rsyslog/trusty/v8-stable/debian/changelog
+++ b/rsyslog/trusty/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.2010.0-0adiscon1trusty1) trusty; urgency=medium
+
+  * Packages for 8.2010.0
+
+ -- Rainer Gerhards <rgerhards@adiscon.com>  Tue, 10 Oct 2020 09:24:57 +0000
+
 rsyslog (8.2008.0-0adiscon1trusty1) trusty; urgency=medium
 
   * Packages for 8.2008.0

--- a/rsyslog/xenial/v8-stable/debian/changelog
+++ b/rsyslog/xenial/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.2010.0-0adiscon1xenial1) xenial; urgency=medium
+
+  * Packages for 8.2010.0
+
+ -- Rainer Gerhards <rgerhards@adiscon.com>  Tue, 10 Oct 2020 09:24:57 +0000
+
 rsyslog (8.2008.0-0adiscon1xenial1) xenial; urgency=medium
 
   * Packages for 8.2008.0


### PR DESCRIPTION
This updates definitions so that SuSe OBS can properly build the
new release. No guarantee on PPA or others.