### PR TITLE
new upstream release 8.2108.0

### DIFF
--- a/rsyslog/Debian/v8-stable/debian/changelog
+++ b/rsyslog/Debian/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.2108.0-1) xenial; urgency=medium
+
+  * Packages for 8.2108.0
+
+ -- Rainer Gerhards <adiscon-pkg-maintainers@adiscon.com>  Tue, 17 Aug 2021 10:17:34 +0000
+
 rsyslog (8.2106.0-1) xenial; urgency=medium
 
   * new upstream release

--- a/rsyslog/bionic/v8-stable/debian/changelog
+++ b/rsyslog/bionic/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.2108.0-0adiscon1bionic1) bionic; urgency=medium
+
+  * Packages for 8.2108.0
+
+ -- Rainer Gerhards <adiscon-pkg-maintainers@adiscon.com>  Tue, 17 Aug 2021 10:17:34 +0000
+
 rsyslog (8.2106.0-0adiscon1bionic1) bionic; urgency=medium
 
   * Packages for 8.2106.0

--- a/rsyslog/eoan/v8-stable/debian/changelog
+++ b/rsyslog/eoan/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.2108.0-0adiscon1eoan1) eoan; urgency=medium
+
+  * Packages for 8.2108.0
+
+ -- Rainer Gerhards <adiscon-pkg-maintainers@adiscon.com>  Tue, 17 Aug 2021 10:17:34 +0000
+
 rsyslog (8.2106.0-0adiscon1eoan1) eoan; urgency=medium
 
   * Packages for 8.2106.0

--- a/rsyslog/focal/v8-stable/debian/changelog
+++ b/rsyslog/focal/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.2108.0-0adiscon1focal1) focal; urgency=medium
+
+  * Packages for 8.2108.0
+
+ -- Rainer Gerhards <adiscon-pkg-maintainers@adiscon.com>  Tue, 17 Aug 2021 10:17:34 +0000
+
 rsyslog (8.2106.0-0adiscon1focal1) focal; urgency=medium
 
   * Packages for 8.2106.0

--- a/rsyslog/groovy/v8-stable/debian/changelog
+++ b/rsyslog/groovy/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.2108.0-0adiscon1groovy1) groovy; urgency=medium
+
+  * Packages for 8.2108.0
+
+ -- Rainer Gerhards <adiscon-pkg-maintainers@adiscon.com>  Tue, 17 Aug 2021 10:17:34 +0000
+
 rsyslog (8.2106.0-0adiscon1groovy1) groovy; urgency=medium
 
   * Packages for 8.2106.0

--- a/rsyslog/trusty/v8-stable/debian/changelog
+++ b/rsyslog/trusty/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.2108.0-0adiscon1trusty1) trusty; urgency=medium
+
+  * Packages for 8.2108.0
+
+ -- Rainer Gerhards <adiscon-pkg-maintainers@adiscon.com>  Tue, 17 Aug 2021 10:17:34 +0000
+
 rsyslog (8.2106.0-0adiscon1trusty1) trusty; urgency=medium
 
   * Packages for 8.2106.0

--- a/rsyslog/xenial/v8-stable/debian/changelog
+++ b/rsyslog/xenial/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.2108.0-0adiscon1xenial1) xenial; urgency=medium
+
+  * Packages for 8.2108.0
+
+ -- Rainer Gerhards <adiscon-pkg-maintainers@adiscon.com>  Tue, 17 Aug 2021 10:17:34 +0000
+
 rsyslog (8.2106.0-0adiscon1xenial1) xenial; urgency=medium
 
   * Packages for 8.2106.0


### PR DESCRIPTION
Previous commit was lost, most probably due to an error during merge.