### PR TITLE
Depend on libhiredis0.14 in Focal

### DIFF
--- a/rsyslog/focal/master/debian/control
+++ b/rsyslog/focal/master/debian/control
@@ -313,7 +313,7 @@ Priority: extra
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          rsyslog (= ${binary:Version}),
-         libhiredis0.13
+         libhiredis0.14
 Description: This module implements Redis support, permitting ryslog to write to redis.
 
 Package: rsyslog-omstdout

--- a/rsyslog/focal/v8-stable/debian/control
+++ b/rsyslog/focal/v8-stable/debian/control
@@ -390,7 +390,7 @@ Priority: extra
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          rsyslog (= ${binary:Version}),
-         libhiredis0.13
+         libhiredis0.14
 Description: This module implements Redis support, permitting ryslog to write to redis.
 
 Package: rsyslog-omstdout


### PR DESCRIPTION
Libhiredis0.13 is not available in focal so this patch changes the dependency to 0.14.
Fixes #139 