### PR TITLE
new upstream release and Debian Bugfix

### DIFF
--- a/rsyslog/Debian/v8-stable/debian/changelog
+++ b/rsyslog/Debian/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.2204.1-1) xenial; urgency=medium
+
+  * Packages for 8.2204.1
+
+ -- Rainer Gerhards <adiscon-pkg-maintainers@adiscon.com>  Thu, 05 May 2022 13:29:59 +0000
+
 rsyslog (8.2204.0-1) xenial; urgency=medium
 
   * Packages for 8.2204.0

--- a/rsyslog/Debian/v8-stable/debian/rsyslog-mmanon.install
+++ b/rsyslog/Debian/v8-stable/debian/rsyslog-mmanon.install
@@ -1,0 +1,1 @@
+debian/tmp/usr/lib/rsyslog/mmanon.so

--- a/rsyslog/Debian/v8-stable/debian/rsyslog-mmrm1stspace.install
+++ b/rsyslog/Debian/v8-stable/debian/rsyslog-mmrm1stspace.install
@@ -1,0 +1,1 @@
+debian/tmp/usr/lib/rsyslog/mmrm1stspace.so

--- a/rsyslog/bionic/v8-stable/debian/changelog
+++ b/rsyslog/bionic/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.2204.1-0adiscon1bionic1) bionic; urgency=medium
+
+  * Packages for 8.2204.1
+
+ -- Rainer Gerhards <adiscon-pkg-maintainers@adiscon.com>  Thu, 05 May 2022 13:29:59 +0000
+
 rsyslog (8.2204.0-0adiscon1bionic1) bionic; urgency=medium
 
   * Packages for 8.2204.0

--- a/rsyslog/bionic/v8-stable/debian/patches/series
+++ b/rsyslog/bionic/v8-stable/debian/patches/series
@@ -1,6 +1,5 @@
 # Debian patches for rsyslog
 01-dont_create_db.patch
-script-compare.patch
 # 0001-build-link-omelasticsearch-against-lm.patch
 # Ubuntu patches for rsyslog
 # 100-imuxsock-allow-missing-date.patch

--- a/rsyslog/eoan/v8-stable/debian/changelog
+++ b/rsyslog/eoan/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.2204.1-0adiscon1eoan1) eoan; urgency=medium
+
+  * Packages for 8.2204.1
+
+ -- Rainer Gerhards <adiscon-pkg-maintainers@adiscon.com>  Thu, 05 May 2022 13:29:59 +0000
+
 rsyslog (8.2204.0-0adiscon1eoan1) eoan; urgency=medium
 
   * Packages for 8.2204.0

--- a/rsyslog/focal/v8-stable/debian/changelog
+++ b/rsyslog/focal/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.2204.1-0adiscon1focal1) focal; urgency=medium
+
+  * Packages for 8.2204.1
+
+ -- Rainer Gerhards <adiscon-pkg-maintainers@adiscon.com>  Thu, 05 May 2022 13:29:59 +0000
+
 rsyslog (8.2204.0-0adiscon1focal1) focal; urgency=medium
 
   * Packages for 8.2204.0

--- a/rsyslog/focal/v8-stable/debian/patches/series
+++ b/rsyslog/focal/v8-stable/debian/patches/series
@@ -1,6 +1,5 @@
 # Debian patches for rsyslog
 01-dont_create_db.patch
-script-compare.patch
 # 0001-build-link-omelasticsearch-against-lm.patch
 # Ubuntu patches for rsyslog
 # 100-imuxsock-allow-missing-date.patch

--- a/rsyslog/groovy/v8-stable/debian/changelog
+++ b/rsyslog/groovy/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.2204.1-0adiscon1groovy1) groovy; urgency=medium
+
+  * Packages for 8.2204.1
+
+ -- Rainer Gerhards <adiscon-pkg-maintainers@adiscon.com>  Thu, 05 May 2022 13:29:59 +0000
+
 rsyslog (8.2204.0-0adiscon1groovy1) groovy; urgency=medium
 
   * Packages for 8.2204.0

--- a/rsyslog/jammy/v8-stable/debian/changelog
+++ b/rsyslog/jammy/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.2204.1-0adiscon3jammy1) jammy; urgency=medium
+
+  * Packages for 8.2204.1
+
+ -- Rainer Gerhards <adiscon-pkg-maintainers@adiscon.com>  Thu, 05 May 2022 13:29:59 +0000
+
 rsyslog (8.2202.0-0adiscon3jammy1) jammy; urgency=medium
 
   * Disabled mmgrok for Jammy due to build error

--- a/rsyslog/trusty/v8-stable/debian/changelog
+++ b/rsyslog/trusty/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.2204.1-0adiscon1trusty1) trusty; urgency=medium
+
+  * Packages for 8.2204.1
+
+ -- Rainer Gerhards <adiscon-pkg-maintainers@adiscon.com>  Thu, 05 May 2022 13:29:59 +0000
+
 rsyslog (8.2204.0-0adiscon1trusty1) trusty; urgency=medium
 
   * Packages for 8.2204.0

--- a/rsyslog/trusty/v8-stable/debian/patches/series
+++ b/rsyslog/trusty/v8-stable/debian/patches/series
@@ -1,6 +1,5 @@
 # Debian patches for rsyslog
 01-dont_create_db.patch
-script-compare.patch
 # 0001-build-link-omelasticsearch-against-lm.patch
 # Ubuntu patches for rsyslog
 # 100-imuxsock-allow-missing-date.patch

--- a/rsyslog/xenial/v8-stable/debian/changelog
+++ b/rsyslog/xenial/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.2204.1-0adiscon1xenial1) xenial; urgency=medium
+
+  * Packages for 8.2204.1
+
+ -- Rainer Gerhards <adiscon-pkg-maintainers@adiscon.com>  Thu, 05 May 2022 13:29:59 +0000
+
 rsyslog (8.2204.0-0adiscon1xenial1) xenial; urgency=medium
 
   * Packages for 8.2204.0

--- a/rsyslog/xenial/v8-stable/debian/patches/series
+++ b/rsyslog/xenial/v8-stable/debian/patches/series
@@ -1,6 +1,5 @@
 # Debian patches for rsyslog
 01-dont_create_db.patch
-script-compare.patch
 # 0001-build-link-omelasticsearch-against-lm.patch
 # Ubuntu patches for rsyslog
 # 100-imuxsock-allow-missing-date.patch


### PR DESCRIPTION
adding OBS Info for new upstream release. Also fixed OBS build for
Debian: mmrm1stspace and mmanon packages were missing binaries.