### PR TITLE
Remove unused grok dependencies and improve PPA upload script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
           ls -l
 
       - name: save ${{ matrix.release }} DEBs
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: debs-${{ matrix.release }}
           path: debs-${{ matrix.release }}
@@ -111,7 +111,7 @@ jobs:
 
     steps:
       - name: Download 20.04 debs
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: debs-20.04
 
@@ -156,7 +156,7 @@ jobs:
 
     steps:
       - name: Download ${{ matrix.release }} debs
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: debs-${{ matrix.release }}
 
@@ -246,7 +246,7 @@ jobs:
           cd $GITHUB_WORKSPACE
 
       - name: save ${{ matrix.release }} DEB Repo
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: repo-${{ matrix.release }}
           path: /var/www/html/repo

--- a/rsyslog/focal/master/debian/control
+++ b/rsyslog/focal/master/debian/control
@@ -11,8 +11,6 @@ Build-Depends: debhelper (>= 12),
                librabbitmq-dev,
                librabbitmq4,
                zlib1g-dev,
-               libgrok-dev,
-               libgrok1,
                libmysqlclient-dev,
                libpq-dev,
 	       libmongoc-dev,
@@ -250,14 +248,14 @@ Depends: ${shlibs:Depends},
          liblognorm5
 Description: Parse all fields of the message into structured data inside the JSON tree.
 
-Package: rsyslog-mmgrok
-Architecture: any
-Priority: extra
-Depends: ${shlibs:Depends},
-         ${misc:Depends},
-         libgrok1,
-         rsyslog (= ${binary:Version}),
-Description: Provides the mmgrok rsyslog plugin
+#Package: rsyslog-mmgrok
+#Architecture: any
+#Priority: extra
+#Depends: ${shlibs:Depends},
+#         ${misc:Depends},
+#         libgrok1,
+#         rsyslog (= ${binary:Version}),
+#Description: Provides the mmgrok rsyslog plugin
 
 Package: rsyslog-omrabbitmq
 Architecture: any
@@ -273,9 +271,9 @@ Architecture: any
 Priority: extra
 Depends: ${shlibs:Depends},
          ${misc:Depends},
-         libgrok1,
          rsyslog (= ${binary:Version}),
 Description: Provides the imdocker rsyslog plugin
+#         libgrok1,
 
 Package: rsyslog-improg
 Architecture: any

--- a/rsyslog/focal/v8-stable/debian/control
+++ b/rsyslog/focal/v8-stable/debian/control
@@ -11,7 +11,6 @@ Build-Depends: debhelper (>= 12),
                librabbitmq-dev,
                librabbitmq4,
                zlib1g-dev,
-               libgrok-dev,
                libmysqlclient-dev,
                libpq-dev,
                libmongoc-dev,
@@ -251,15 +250,15 @@ Depends: ${shlibs:Depends},
          liblognorm5
 Description: Parse all fields of the message into structured data inside the JSON tree.
 
-Package: rsyslog-mmgrok
-Architecture: any
-Priority: extra
-Depends: ${shlibs:Depends},
-         ${misc:Depends},
-         libgrok1,
-         libgrok-dev,
-         rsyslog (= ${binary:Version}),
-Description: Provides the mmgrok rsyslog plugin
+#Package: rsyslog-mmgrok
+#Architecture: any
+#Priority: extra
+#Depends: ${shlibs:Depends},
+#         ${misc:Depends},
+#         libgrok1,
+#         libgrok-dev,
+#         rsyslog (= ${binary:Version}),
+#Description: Provides the mmgrok rsyslog plugin
 
 Package: rsyslog-omrabbitmq
 Architecture: any
@@ -275,9 +274,9 @@ Architecture: any
 Priority: extra
 Depends: ${shlibs:Depends},
          ${misc:Depends},
-         libgrok1,
          rsyslog (= ${binary:Version}),
 Description: Provides the imdocker rsyslog plugin
+#         libgrok1,
 
 Package: rsyslog-improg
 Architecture: any

--- a/rsyslog/focal/v8-stable/debian/rules
+++ b/rsyslog/focal/v8-stable/debian/rules
@@ -25,7 +25,6 @@ override_dh_auto_configure:
 		--enable-omrabbitmq \
 		--enable-imczmq \
 		--enable-omczmq \
-		--enable-mmgrok \
 		--enable-omuxsock \
 		--enable-mysql \
 		--enable-pgsql \
@@ -73,6 +72,7 @@ override_dh_auto_configure:
 		--with-systemdsystemunitdir=/lib/systemd/system
 
 #
+#		--enable-mmgrok \
 #		--enable-omkafka \
 #		 --enable-guardtime \
 #		 --enable-gt-ksi \

--- a/rsyslog/noble/v8-stable/debian/control
+++ b/rsyslog/noble/v8-stable/debian/control
@@ -11,7 +11,6 @@ Build-Depends: debhelper (>= 12),
                librabbitmq-dev,
                librabbitmq4,
                zlib1g-dev,
-               libgrok-dev,
                libtirpc-dev,
                libmysqlclient-dev,
                libpq-dev,
@@ -252,15 +251,15 @@ Depends: ${shlibs:Depends},
          liblognorm5
 Description: Parse all fields of the message into structured data inside the JSON tree.
 
-Package: rsyslog-mmgrok
-Architecture: any
-Priority: extra
-Depends: ${shlibs:Depends},
-         ${misc:Depends},
-         libgrok1,
-         libtirpc3,
-         rsyslog (= ${binary:Version}),
-Description: Provides the mmgrok rsyslog plugin
+#Package: rsyslog-mmgrok
+#Architecture: any
+#Priority: extra
+#Depends: ${shlibs:Depends},
+#         ${misc:Depends},
+#         libgrok1,
+#         libtirpc3,
+#         rsyslog (= ${binary:Version}),
+#Description: Provides the mmgrok rsyslog plugin
 
 Package: rsyslog-omrabbitmq
 Architecture: any
@@ -276,9 +275,9 @@ Architecture: any
 Priority: extra
 Depends: ${shlibs:Depends},
          ${misc:Depends},
-         libgrok1,
          rsyslog (= ${binary:Version}),
 Description: Provides the imdocker rsyslog plugin
+#         libgrok1,
 
 Package: rsyslog-improg
 Architecture: any

--- a/rsyslog/noble/v8-stable/debian/rules
+++ b/rsyslog/noble/v8-stable/debian/rules
@@ -26,7 +26,6 @@ override_dh_auto_configure:
 		--enable-omrabbitmq \
 		--enable-imczmq \
 		--enable-omczmq \
-		--enable-mmgrok \
 		--enable-omuxsock \
 		--enable-mysql \
 		--enable-pgsql \
@@ -74,6 +73,7 @@ override_dh_auto_configure:
 		--with-systemdsystemunitdir=/lib/systemd/system
 
 #
+#		--enable-mmgrok \
 #		--enable-omkafka \
 #		 --enable-guardtime \
 #		 --enable-gt-ksi \

--- a/scripts/uploadppa.sh
+++ b/scripts/uploadppa.sh
@@ -4,11 +4,8 @@ echo load config from $(dirname "$0")/config.sh
 
 source $(dirname "$0")/config.sh
 
-#set -o xtrace  # use for debugging
-
 # If we assume the directory is named after the package,
 PACKAGENAME=$(basename `readlink -f .`)
-#PACKAGENAME="$PACKAGENAME`cat CURR_LIBSONAME`"
 TARGZFILES=` ls -d */ | grep $PACKAGENAME`
 echo TARG: $TARGZFILES
 
@@ -25,42 +22,77 @@ echo "--- Prep Release for $TARGZFILES"
 echo "-------------------------------------------"
 szPrepareDir=$TARGZFILES
 echo "Select package repository:"
-select szBranch in $BRANCHES
+select UPLOAD_PPA in $BRANCHES
 do
-	echo "Select Ubuntu DIST:"
-	select szPlatform in $PLATFORM
-	do
-		break;
-	done
-	break;
+    echo "Select Ubuntu DIST:"
+    select szPlatform in $PLATFORM
+    do
+        break;
+    done
+    break;
 done
 
-#szSourceBase=`basename $szSourceFile .tar.gz`
-#szSourceBase=`echo $szSourceBase | sed 's/_/-/'`
-#
-#echo "$szSourceBase";
-#exit; 
+# Set Debian branch based on available subfolders in $szPlatform
+DEBIAN_BRANCHES=($(ls -d $szPlatform/*/ | xargs -n 1 basename))
+if [ ${#DEBIAN_BRANCHES[@]} -eq 0 ]; then
+    echo "No available Debian branch subfolders found in $szPlatform"
+    exit 1
+fi
 
-#tar xfz $szSourceFile 
-#mv $szSourceFile $szReplaceFile.orig.tar.gz
+echo "Select Debian branch:"
+select szBranch in "${DEBIAN_BRANCHES[@]}"
+do
+    if [ -n "$szBranch" ]; then
+        break;
+    fi
+    echo "Invalid selection. Please try again."
+done
 
-read -p "Generate Changelog entry for $szPlatform/$szBranch (y/n)? " RESULT
+# Get VERSION from the tarball name
+VERSION=$(echo $TARGZFILES | grep -oP '(?<=-)[0-9]+\.[0-9]+\.[0-9]+')
+
+if [ -z "$VERSION" ]; then
+    echo "Unable to determine version from tarball name."
+    exit 1
+fi
+
+echo "Using PPA: $UPLOAD_PPA"
+echo "Using Debian branch: $szBranch"
+echo "Detected VERSION: $VERSION"
+
+read -p "Generate Changelog entry for $szPlatform/$szBranch automatically (y/n)? " GEN_CHANGELOG
 cp -r $szPlatform/$szBranch/debian $szPrepareDir || exit 1
 cd $szPrepareDir
-if [ "$RESULT" == "y" ]; then
-	dch -D $szPlatform -i
+if [ "$GEN_CHANGELOG" == "y" ]; then
+    read -p "Enter SUBVERSION number (default is 1): " SUBVERSION
+    SUBVERSION=${SUBVERSION:-1}
+    echo "Using SUBVERSION: $SUBVERSION"
+
+    NEW_ENTRY="$PACKAGENAME ($VERSION-0adiscon1$szPlatform$SUBVERSION) $szPlatform; urgency=low
+
+  * Packages for ${VERSION} on ${szPlatform}
+
+ -- Adiscon package maintainers <adiscon-pkg-maintainers@adiscon.com>  $(date -R)"
+    echo -e "$NEW_ENTRY\n$(cat debian/changelog)" > debian/changelog
+    echo "Automatic changelog entry added:"
+    echo "$NEW_ENTRY"
+else
+    read -p "Generate Changelog entry for $szPlatform/$szBranch (y/n)? " GEN_CHANGELOG
+    if [ "$GEN_CHANGELOG" == "y" ]; then
+        dch -D $szPlatform -i
+    fi
 fi
 
 # Build Source package now!
 if [ -v PACKAGE_SIGNING_KEY_ID ]; then
-	echo "RUN debuild -S -sa -rfakeroot -k $PACKAGE_SIGNING_KEY_ID
-	debuild -S -sa -rfakeroot -k"$PACKAGE_SIGNING_KEY_ID"
+    echo "RUN debuild -S -sa -rfakeroot -k $PACKAGE_SIGNING_KEY_ID"
+    debuild -S -sa -rfakeroot -k"$PACKAGE_SIGNING_KEY_ID"
 else
-	echo "RUN WITHOUT KEY debuild -S -sa -rfakeroot -us -uc
+    echo "RUN WITHOUT KEY debuild -S -sa -rfakeroot -us -uc"
     debuild -S -sa -rfakeroot -us -uc
 fi
 if [ $? -ne 0 ]; then
-	echo "FAIL in debuild for $PACKAGENAME $VERSION on $szPlatform"
+    echo "FAIL in debuild for $PACKAGENAME $VERSION on $szPlatform"
     exit 1
 fi
 
@@ -71,15 +103,15 @@ chmod -f g+w *
 # files are generated in the home directory.
 cd ..
 
-if [ "$RESULT" == "y" ]; then
-	szDebian="debian"
-	echo    # (optional) move to a new line
-	read -p "Copy $szPrepareDir$szDebian folder back to $szPlatform/$szBranch/$szDebian (y/n)? " RESULT
-	echo    # (optional) move to a new line 
-	if [ "$RESULT" == "y" ]; then
-		cp -r $szPrepareDir$szDebian $szPlatform/$szBranch/
-		echo "$szPrepareDir$szDebian copied back."
-	fi
+if [ "$GEN_CHANGELOG" == "y" ]; then
+    szDebian="debian"
+    echo    # (optional) move to a new line
+    read -p "Copy $szPrepareDir$szDebian folder back to $szPlatform/$szBranch/$szDebian (y/n)? " COPYBACK
+    echo    # (optional) move to a new line 
+    if [ "$COPYBACK" == "y" ]; then
+        cp -r $szPrepareDir$szDebian $szPlatform/$szBranch/
+        echo "$szPrepareDir$szDebian copied back."
+    fi
 fi
 
 echo "-------------------------------------"
@@ -93,28 +125,28 @@ echo "-------------------------------------"
 CHANGESFILES=`ls *.changes`
 
 if [ -z "$CHANGESFILES" ]; then
-	echo "FAILED: ls *.changes No changefiles found"
-	exit 1
+    echo "FAILED: ls *.changes No changefiles found"
+    exit 1
 fi
 
 echo "Select Changefile:"
 select szChangeFile in $CHANGESFILES
 do
-	break;
+    break;
 done
 
 # Upload changes to PPA now!
 echo "Sign $szChangeFile"
 debsign -k $PACKAGE_SIGNING_KEY_ID $szChangeFile
-echo "Upload to ppa:adiscon/$szBranch"
-dput -f ppa:adiscon/$szBranch $szChangeFile
+echo "Upload to $UPLOAD_PPA"
+dput -f ppa:adiscon/$UPLOAD_PPA $szChangeFile
 if [ $? -ne 0 ]; then
-	echo "FAILED dput, PPA upload to Launchpad ppa:adiscon/$szBranch for $PACKAGENAME failed"
-	exit 1
+    echo "FAILED dput, PPA upload to Launchpad $UPLOAD_PPA for $PACKAGENAME failed"
+    exit 1
 fi
 
 # cleanup
 rm -v *.changes
-rm -v *.debian.tar.gz
+rm -v *.debian.tar.xz
 # Fix filepermissions
 chmod -f g+w *


### PR DESCRIPTION
- Removed `libgrok-dev` and `libgrok1` dependencies from `debian/control` files in both `focal/master` and `focal/v8-stable` branches.
- Commented out unused `rsyslog-mmgrok` package references, streamlining dependency management and package definitions.
- Enhanced `uploadppa.sh` script with improvements:
  - Added Debian branch selection based on available directories.
  - Automatically generates a changelog entry when opted for.
  - Refined PPA upload handling, utilizing `$UPLOAD_PPA` variable.

closes: https://github.com/rsyslog/rsyslog-pkg-ubuntu/issues/175