### PR TITLE
Add rsyslog-imbeats packaging for focal, jammy, and noble

### DIFF
--- a/.github/workflows/install-rsyslog-packages-from-obs.yml
+++ b/.github/workflows/install-rsyslog-packages-from-obs.yml
@@ -198,5 +198,8 @@ jobs:
       - name: Install rsyslog-impcap
         run: sudo apt-get install rsyslog-impcap
 
+      - name: Install rsyslog-imbeats
+        run: sudo apt-get install rsyslog-imbeats
+
       - name: Display installed rsyslog packages
         run: dpkg -l | grep -E 'rsyslog|adiscon'

--- a/.github/workflows/install-rsyslog-packages-from-ppa.yml
+++ b/.github/workflows/install-rsyslog-packages-from-ppa.yml
@@ -199,6 +199,9 @@ jobs:
       - name: Install rsyslog-impcap
         run: sudo apt-get install rsyslog-impcap
 
+      - name: Install rsyslog-imbeats
+        run: sudo apt-get install rsyslog-imbeats
+
       - name: Display installed rsyslog packages
         run: dpkg -l | grep -E 'rsyslog|adiscon'
 
@@ -352,6 +355,9 @@ jobs:
 
       - name: Install rsyslog-impcap
         run: sudo apt-get install rsyslog-impcap
+
+      - name: Install rsyslog-imbeats
+        run: sudo apt-get install rsyslog-imbeats
 
       - name: Display installed rsyslog packages
         run: dpkg -l | grep -E 'rsyslog|adiscon'

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Sub-packages for rsyslog to provide specific functionality:
 - rsyslog-doc
 - rsyslog-elasticsearch
 - rsyslog-imptcp
+- rsyslog-imbeats
 - rsyslog-kafka (>=14.04)
 - rsyslog-mmanon
 - rsyslog-mmfields

--- a/rsyslog/focal/v8-stable/debian/changelog
+++ b/rsyslog/focal/v8-stable/debian/changelog
@@ -1,3 +1,8 @@
+rsyslog (8.2604.0-0adiscon1focal1) focal; urgency=low
+
+  * Packages for 8.2604.0 on focal
+
+ -- Adiscon package maintainers <adiscon-pkg-maintainers@adiscon.com>  Tue, 21 Apr 2026 08:48:57 +0000
 rsyslog (8.2512.0-0adiscon1focal1) focal; urgency=low
 
   * Packages for 8.2512.0 on focal

--- a/rsyslog/focal/v8-stable/debian/changelog
+++ b/rsyslog/focal/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.2604.0-0adiscon1focal2) focal; urgency=low
+
+  * Add rsyslog-imbeats package (imbeats input module, --enable-imbeats).
+
+ -- Adiscon package maintainers <adiscon-pkg-maintainers@adiscon.com>  Mon, 11 May 2026 12:00:00 +0000
+
 rsyslog (8.2604.0-0adiscon1focal1) focal; urgency=low
 
   * Packages for 8.2604.0 on focal

--- a/rsyslog/focal/v8-stable/debian/control
+++ b/rsyslog/focal/v8-stable/debian/control
@@ -474,3 +474,15 @@ Description: HTTP output plugin for rsyslog
  This package provides the omhttp module, enabling rsyslog to transmit log messages
  to remote HTTP or HTTPS endpoints. It facilitates integration with web services,
  APIs, and modern centralized log management platforms that accept logs over HTTP.
+
+Package: rsyslog-imbeats
+Architecture: any
+Priority: extra
+Depends: ${shlibs:Depends},
+         ${misc:Depends},
+         rsyslog (= ${binary:Version})
+Suggests: rsyslog-openssl | rsyslog-gnutls
+Description: Elastic Beats / Elastic Agent input for rsyslog
+ This package provides the `imbeats` input module, which receives events from
+ Elastic Beats and Elastic Agent using the Lumberjack v2 protocol over TCP or
+ TLS (via the same stream drivers as other rsyslog network inputs).

--- a/rsyslog/focal/v8-stable/debian/rsyslog-imbeats.install
+++ b/rsyslog/focal/v8-stable/debian/rsyslog-imbeats.install
@@ -1,0 +1,1 @@
+debian/tmp/usr/lib/rsyslog/imbeats.so

--- a/rsyslog/focal/v8-stable/debian/rules
+++ b/rsyslog/focal/v8-stable/debian/rules
@@ -62,6 +62,7 @@ override_dh_auto_configure:
 		--enable-pmnull \
 		--enable-omkafka \
 		--enable-imkafka \
+		--enable-imbeats \
 		--enable-omhiredis \
 		--enable-omstdout \
 		--enable-openssl \

--- a/rsyslog/jammy/v8-stable/debian/changelog
+++ b/rsyslog/jammy/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.2604.0-0adiscon1jammy2) jammy; urgency=low
+
+  * Add rsyslog-imbeats package (imbeats input module, --enable-imbeats).
+
+ -- Adiscon package maintainers <adiscon-pkg-maintainers@adiscon.com>  Mon, 11 May 2026 12:00:00 +0000
+
 rsyslog (8.2604.0-0adiscon1jammy1) jammy; urgency=low
 
   * Packages for 8.2604.0 on jammy

--- a/rsyslog/jammy/v8-stable/debian/changelog
+++ b/rsyslog/jammy/v8-stable/debian/changelog
@@ -1,3 +1,8 @@
+rsyslog (8.2604.0-0adiscon1jammy1) jammy; urgency=low
+
+  * Packages for 8.2604.0 on jammy
+
+ -- Adiscon package maintainers <adiscon-pkg-maintainers@adiscon.com>  Tue, 21 Apr 2026 08:18:20 +0000
 rsyslog (8.2512.0-0adiscon1jammy1) jammy; urgency=low
 
   * Packages for 8.2512.0 on jammy

--- a/rsyslog/jammy/v8-stable/debian/control
+++ b/rsyslog/jammy/v8-stable/debian/control
@@ -510,3 +510,15 @@ Description: HTTP input module for rsyslog
  as a lightweight HTTP server, accepting logs from applications or services
  that communicate over HTTP instead of traditional syslog protocols.
 
+Package: rsyslog-imbeats
+Architecture: any
+Priority: extra
+Depends: ${shlibs:Depends},
+         ${misc:Depends},
+         rsyslog (= ${binary:Version})
+Suggests: rsyslog-openssl | rsyslog-gnutls
+Description: Elastic Beats / Elastic Agent input for rsyslog
+ This package provides the `imbeats` input module, which receives events from
+ Elastic Beats and Elastic Agent using the Lumberjack v2 protocol over TCP or
+ TLS (via the same stream drivers as other rsyslog network inputs).
+

--- a/rsyslog/jammy/v8-stable/debian/files
+++ b/rsyslog/jammy/v8-stable/debian/files
@@ -1,1 +1,1 @@
-rsyslog_8.2512.0-0adiscon1jammy1_source.buildinfo admin important
+rsyslog_8.2604.0-0adiscon1jammy1_source.buildinfo admin important

--- a/rsyslog/jammy/v8-stable/debian/rsyslog-imbeats.install
+++ b/rsyslog/jammy/v8-stable/debian/rsyslog-imbeats.install
@@ -1,0 +1,1 @@
+debian/tmp/usr/lib/rsyslog/imbeats.so

--- a/rsyslog/jammy/v8-stable/debian/rules
+++ b/rsyslog/jammy/v8-stable/debian/rules
@@ -78,6 +78,7 @@ override_dh_auto_configure: build-qpid-proton
 		--enable-debug-symbols \
 		--enable-omhttp \
 		--enable-imhttp \
+		--enable-imbeats \
 		--disable-testbench \
 		--disable-liblogging-stdlog \
 		--with-systemdsystemunitdir=/lib/systemd/system

--- a/rsyslog/noble/v8-stable/debian/changelog
+++ b/rsyslog/noble/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.2604.0-0adiscon1noble2) noble; urgency=low
+
+  * Add rsyslog-imbeats package (imbeats input module, --enable-imbeats).
+
+ -- Adiscon package maintainers <adiscon-pkg-maintainers@adiscon.com>  Mon, 11 May 2026 12:00:00 +0000
+
 rsyslog (8.2604.0-0adiscon1noble1) noble; urgency=low
 
   * Packages for 8.2604.0 on noble

--- a/rsyslog/noble/v8-stable/debian/changelog
+++ b/rsyslog/noble/v8-stable/debian/changelog
@@ -1,3 +1,8 @@
+rsyslog (8.2604.0-0adiscon1noble1) noble; urgency=low
+
+  * Packages for 8.2604.0 on noble
+
+ -- Adiscon package maintainers <adiscon-pkg-maintainers@adiscon.com>  Tue, 21 Apr 2026 08:19:06 +0000
 rsyslog (8.2512.0-0adiscon1noble8) noble; urgency=low
 
   * Packages for 8.2512.0 on noble

--- a/rsyslog/noble/v8-stable/debian/control
+++ b/rsyslog/noble/v8-stable/debian/control
@@ -395,3 +395,15 @@ Description: HTTP input module for rsyslog
  receiving log messages via HTTP POST requests. It enables rsyslog to act
  as a lightweight HTTP server, accepting logs from applications or services
  that communicate over HTTP instead of traditional syslog protocols.
+
+Package: rsyslog-imbeats
+Architecture: any
+Priority: extra
+Depends: ${shlibs:Depends},
+         ${misc:Depends},
+         rsyslog (= ${binary:Version})
+Suggests: rsyslog-openssl | rsyslog-gnutls
+Description: Elastic Beats / Elastic Agent input for rsyslog
+ This package provides the `imbeats` input module, which receives events from
+ Elastic Beats and Elastic Agent using the Lumberjack v2 protocol over TCP or
+ TLS (via the same stream drivers as other rsyslog network inputs).

--- a/rsyslog/noble/v8-stable/debian/files
+++ b/rsyslog/noble/v8-stable/debian/files
@@ -1,1 +1,1 @@
-rsyslog_8.2512.0-0adiscon1noble8_source.buildinfo admin optional
+rsyslog_8.2604.0-0adiscon1noble1_source.buildinfo admin optional

--- a/rsyslog/noble/v8-stable/debian/rsyslog-imbeats.install
+++ b/rsyslog/noble/v8-stable/debian/rsyslog-imbeats.install
@@ -1,0 +1,1 @@
+usr/lib/${DEB_HOST_MULTIARCH}/rsyslog/imbeats.so

--- a/rsyslog/noble/v8-stable/debian/rules
+++ b/rsyslog/noble/v8-stable/debian/rules
@@ -89,6 +89,7 @@ override_dh_auto_configure: build-qpid-proton
 		--enable-omsendertrack \
 		--enable-omhttp \
 		--enable-imhttp \
+		--enable-imbeats \
 		--disable-libgcrypt \
 		--disable-generate-man-pages \
 		--disable-fmhttp \


### PR DESCRIPTION
Enable the upstream imbeats input module with --enable-imbeats in
debian/rules for all v8-stable suites. Add binary package rsyslog-imbeats
(control + rsyslog-imbeats.install) splitting imbeats.so from the base
rsyslog package, with Suggests on rsyslog-openssl | rsyslog-gnutls for TLS.
Bump Debian changelog revisions (noble2, jammy2, focal2).

Document the sub-package in README.md and install rsyslog-imbeats in
PPA and OBS smoke workflows after rsyslog-impcap.

Requires an rsyslog source tarball that includes plugins/imbeats/ (e.g.
v8.2606+); older upstream tags without imbeats will fail at configure time.