### PR TITLE
debian: add autoconf-archive Build-Depends for focal and jammy

### DIFF
--- a/rsyslog/focal/v8-stable/debian/changelog
+++ b/rsyslog/focal/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.2604.0-0adiscon1focal4) focal; urgency=low
+
+  * Add Build-Depends on autoconf-archive for AX_* configure macros (dh_autoreconf).
+
+ -- Adiscon package maintainers <adiscon-pkg-maintainers@adiscon.com>  Mon, 01 Jun 2026 12:00:00 +0000
+
 rsyslog (8.2604.0-0adiscon1focal3) focal; urgency=low
 
   * Add rsyslog-omotel package (omotel output module, --enable-omotel).

--- a/rsyslog/focal/v8-stable/debian/control
+++ b/rsyslog/focal/v8-stable/debian/control
@@ -5,6 +5,7 @@ Maintainer: Andre Lorbach <alorbach@adiscon.com>
 XSBC-Original-Maintainer: Michael Biebl <biebl@debian.org>
 Build-Depends: debhelper (>= 12),
                dpkg-dev (>= 1.6.1),
+               autoconf-archive,
                autotools-dev (>= 20100122.1),
                libczmq-dev (>= 4.0.0),
                dh-autoreconf,

--- a/rsyslog/jammy/v8-stable/debian/changelog
+++ b/rsyslog/jammy/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.2604.0-0adiscon1jammy4) jammy; urgency=low
+
+  * Add Build-Depends on autoconf-archive for AX_* configure macros (dh_autoreconf).
+
+ -- Adiscon package maintainers <adiscon-pkg-maintainers@adiscon.com>  Mon, 01 Jun 2026 12:00:00 +0000
+
 rsyslog (8.2604.0-0adiscon1jammy3) jammy; urgency=low
 
   * Add rsyslog-omotel package (omotel output module, --enable-omotel).

--- a/rsyslog/jammy/v8-stable/debian/control
+++ b/rsyslog/jammy/v8-stable/debian/control
@@ -5,6 +5,7 @@ Maintainer: Andre Lorbach <alorbach@adiscon.com>
 XSBC-Original-Maintainer: Michael Biebl <biebl@debian.org>
 Build-Depends: debhelper (>= 12),
                dpkg-dev (>= 1.6.1),
+               autoconf-archive,
                autotools-dev (>= 20100122.1),
                libczmq-dev (>= 4.0.0),
                dh-autoreconf,


### PR DESCRIPTION
After rsyslog commit cf6496293, configure.ac requires AX_IS_RELEASE, AX_COMPILER_FLAGS, and related autoconf-archive macros during dh_autoreconf. Focal and jammy packaging omitted that dependency, so Launchpad binary builds failed; noble already had it.