### PR TITLE
fix(packaging): ship GitHub releases when Ubuntu primary orig tarball…

### DIFF
--- a/liblognorm/focal/v8-stable/debian/changelog
+++ b/liblognorm/focal/v8-stable/debian/changelog
@@ -1,3 +1,18 @@
+liblognorm (2.1.0-0adiscon1focal3) focal; urgency=low
+
+  * Packages for 2.1.0 on focal
+
+ -- Adiscon package maintainers <adiscon-pkg-maintainers@adiscon.com>  Tue, 30 Jun 2026 15:06:23 +0000
+liblognorm (2.1.0-0adiscon1focal2) focal; urgency=low
+
+  * Packages for 2.1.0 on focal
+
+ -- Adiscon package maintainers <adiscon-pkg-maintainers@adiscon.com>  Tue, 30 Jun 2026 12:13:29 +0000
+liblognorm (2.1.0-0adiscon1focal1) focal; urgency=low
+
+  * Packages for 2.1.0 on focal
+
+ -- Adiscon package maintainers <adiscon-pkg-maintainers@adiscon.com>  Tue, 30 Jun 2026 11:04:01 +0000
 liblognorm (2.0.8-0adiscon1focal1) focal; urgency=low
 
   * Packages for 2.0.8 on focal

--- a/liblognorm/jammy/v8-stable/debian/changelog
+++ b/liblognorm/jammy/v8-stable/debian/changelog
@@ -1,3 +1,23 @@
+liblognorm (2.1.0+adiscon1-0adiscon1jammy5) jammy; urgency=low
+
+  * Packages for 2.1.0+adiscon1 on jammy
+
+ -- Adiscon package maintainers <adiscon-pkg-maintainers@adiscon.com>  Wed, 01 Jul 2026 10:47:03 +0000
+liblognorm (2.1.0-0adiscon1jammy3) jammy; urgency=low
+
+  * Packages for 2.1.0 on jammy
+
+ -- Adiscon package maintainers <adiscon-pkg-maintainers@adiscon.com>  Tue, 30 Jun 2026 15:06:41 +0000
+liblognorm (2.1.0-0adiscon1jammy2) jammy; urgency=low
+
+  * Packages for 2.1.0 on jammy
+
+ -- Adiscon package maintainers <adiscon-pkg-maintainers@adiscon.com>  Tue, 30 Jun 2026 12:13:54 +0000
+liblognorm (2.1.0-0adiscon1jammy1) jammy; urgency=low
+
+  * Packages for 2.1.0 on jammy
+
+ -- Adiscon package maintainers <adiscon-pkg-maintainers@adiscon.com>  Tue, 30 Jun 2026 11:04:22 +0000
 liblognorm (2.0.8-0adiscon1jammy1) jammy; urgency=low
 
   * Packages for 2.0.8 on jammy

--- a/liblognorm/noble/v8-stable/debian/changelog
+++ b/liblognorm/noble/v8-stable/debian/changelog
@@ -1,3 +1,28 @@
+liblognorm (2.1.0+adiscon1-0adiscon1noble5) noble; urgency=low
+
+  * Packages for 2.1.0+adiscon1 on noble
+
+ -- Adiscon package maintainers <adiscon-pkg-maintainers@adiscon.com>  Wed, 01 Jul 2026 10:27:54 +0000
+liblognorm (2.1.0+adiscon1-0adiscon1noble4) noble; urgency=low
+
+  * Packages for 2.1.0+adiscon1 on noble
+
+ -- Adiscon package maintainers <adiscon-pkg-maintainers@adiscon.com>  Wed, 01 Jul 2026 10:21:09 +0000
+liblognorm (2.1.0-0adiscon1noble3) noble; urgency=low
+
+  * Packages for 2.1.0 on noble
+
+ -- Adiscon package maintainers <adiscon-pkg-maintainers@adiscon.com>  Tue, 30 Jun 2026 15:07:06 +0000
+liblognorm (2.1.0-0adiscon1noble2) noble; urgency=low
+
+  * Packages for 2.1.0 on noble
+
+ -- Adiscon package maintainers <adiscon-pkg-maintainers@adiscon.com>  Tue, 30 Jun 2026 12:14:15 +0000
+liblognorm (2.1.0-0adiscon1noble1) noble; urgency=low
+
+  * Packages for 2.1.0 on noble
+
+ -- Adiscon package maintainers <adiscon-pkg-maintainers@adiscon.com>  Thu, 25 Jun 2026 14:59:25 +0000
 liblognorm (2.0.7-0adiscon1noble1) noble; urgency=low
 
   * Packages for 2.0.7 on noble

--- a/rsyslog/focal/v8-stable/debian/changelog
+++ b/rsyslog/focal/v8-stable/debian/changelog
@@ -1,3 +1,8 @@
+rsyslog (8.2606.0-0adiscon1focal1) focal; urgency=low
+
+  * Packages for 8.2606.0 on focal
+
+ -- Adiscon package maintainers <adiscon-pkg-maintainers@adiscon.com>  Tue, 23 Jun 2026 14:17:58 +0000
 rsyslog (8.2604.0-0adiscon1focal4) focal; urgency=low
 
   * Add Build-Depends on autoconf-archive for AX_* configure macros (dh_autoreconf).

--- a/rsyslog/jammy/v8-stable/debian/changelog
+++ b/rsyslog/jammy/v8-stable/debian/changelog
@@ -1,3 +1,8 @@
+rsyslog (8.2606.0-0adiscon1jammy1) jammy; urgency=low
+
+  * Packages for 8.2606.0 on jammy
+
+ -- Adiscon package maintainers <adiscon-pkg-maintainers@adiscon.com>  Tue, 23 Jun 2026 14:18:35 +0000
 rsyslog (8.2604.0-0adiscon1jammy4) jammy; urgency=low
 
   * Add Build-Depends on autoconf-archive for AX_* configure macros (dh_autoreconf).

--- a/rsyslog/jammy/v8-stable/debian/files
+++ b/rsyslog/jammy/v8-stable/debian/files
@@ -1,1 +1,1 @@
-rsyslog_8.2604.0-0adiscon1jammy1_source.buildinfo admin important
+rsyslog_8.2606.0-0adiscon1jammy1_source.buildinfo admin important

--- a/rsyslog/noble/v8-stable/debian/changelog
+++ b/rsyslog/noble/v8-stable/debian/changelog
@@ -1,3 +1,8 @@
+rsyslog (8.2606.0-0adiscon1noble1) noble; urgency=low
+
+  * Packages for 8.2606.0 on noble
+
+ -- Adiscon package maintainers <adiscon-pkg-maintainers@adiscon.com>  Tue, 23 Jun 2026 14:19:22 +0000
 rsyslog (8.2604.0-0adiscon1noble3) noble; urgency=low
 
   * Add rsyslog-omotel package (omotel output module, --enable-omotel).

--- a/rsyslog/noble/v8-stable/debian/files
+++ b/rsyslog/noble/v8-stable/debian/files
@@ -1,1 +1,1 @@
-rsyslog_8.2604.0-0adiscon1noble1_source.buildinfo admin optional
+rsyslog_8.2606.0-0adiscon1noble1_source.buildinfo admin optional

--- a/scripts/DOC.md
+++ b/scripts/DOC.md
@@ -11,7 +11,7 @@ Scripts for building and publishing Debian/Ubuntu packages for rsyslog and relat
 | Script | Purpose |
 |--------|--------|
 | **auto_daily.sh** | Top-level daily build: for each project and each platform (focal, jammy, noble), copies tarball from `$INFRAHOME/repo/<project>/` and runs `auto_daily_project.sh`. **Args:** `[PROJECTS] [PPAREPO] [PPABRANCH] [CUSTOMBUILD]`. Example: `./auto_daily.sh rsyslog daily-stable v8-stable`. |
-| **auto_daily_project.sh** | Build one project for one Ubuntu suite. **Must be run from the project dir** (e.g. `rsyslog/`). Extracts tarball, overlays `../<platform>/<branch>/debian`, runs debuild, optionally signs and uploads to PPA. **Args:** `PLATFORM UPLOAD_PPA BRANCH [CUSTOMBUILD]`. Library projects can have a `CURR_LIBSONAME` file (e.g. `4` for libfastjson4). |
+| **auto_daily_project.sh** | Build one project for one Ubuntu suite. **Must be run from the project dir** (e.g. `rsyslog/`). Extracts tarball, overlays `../<platform>/<branch>/debian`, runs debuild, optionally signs and uploads to PPA. **Args:** `PLATFORM UPLOAD_PPA BRANCH [CUSTOMBUILD] [debuild-mode]`. Optional 5th arg `sd` selects `debuild -sd` (packaging-only; orig must already be on PPA). Default is `-sa`. Library projects can have a `CURR_LIBSONAME` file (e.g. `4` for libfastjson4). |
 | **full_rebuild.sh** | Removes all `LAST_*` version files so the next daily run will rebuild and re-upload every project/suite. Run from repo root. |
 | **install_rsyslog_builddeps.sh** | Install build-deps needed for `debuild` on the build host (libprotobuf-c-dev, libsnappy-dev, protobuf-c-compiler, libyaml-dev). Run once: `sudo ./scripts/install_rsyslog_builddeps.sh`. |
 
@@ -21,7 +21,7 @@ Scripts for building and publishing Debian/Ubuntu packages for rsyslog and relat
 
 | Script | Purpose |
 |--------|--------|
-| **uploadppa.sh** | Interactive: choose extracted package dir, PPA branch, and Ubuntu dist; copy debian from `$szPlatform/$szBranch/debian`, build source package (debuild -S), optionally add changelog, then sign and dput to `ppa:adiscon/$UPLOAD_PPA`. Run from a project dir (e.g. `rsyslog/`) that contains exactly one `$PACKAGENAME*/` directory. |
+| **uploadppa.sh** | Interactive: choose extracted package dir, PPA branch, and Ubuntu dist; copy debian from `$szPlatform/$szBranch/debian`, build source package (`debuild -S -sa` or `-sd`), optionally add changelog, then sign and dput to `ppa:adiscon/$UPLOAD_PPA`. Supports vendor upstream versions (e.g. `2.1.0+adiscon1`). Run from a project dir that contains exactly one `$PACKAGENAME*/` directory. |
 | **prepare.sh** | Interactive: choose package dir, branch, and platform; copy debian in, run `dch -D $szPlatform -i` and debuild -S, then optionally copy debian back to `$szPlatform/$szBranch/debian`. Uses `KEY_ID` (may need to be set; config has `PACKAGE_SIGNING_KEY_ID`). Run from project parent. |
 | **updaterelease.sh** | Interactive: choose rsyslog dir, run dch -i and debuild -S. Uses `KEY_ID`. Run from directory that contains `rsyslog*/` dirs. |
 
@@ -31,7 +31,8 @@ Scripts for building and publishing Debian/Ubuntu packages for rsyslog and relat
 
 | Script | Purpose |
 |--------|--------|
-| **repack.sh** | Download a tarball by URL (`$1`), extract it, and rename to `*.orig.tar.gz` (Debian convention). Run from project dir; only one `.tar.gz` allowed. |
+| **repack.sh** | Download a tarball by URL (`$1`), extract it, and rename to `*.orig.tar.gz` (Debian convention). Optional vendor suffix (`$2`, e.g. `+adiscon1`) when the plain upstream version conflicts with Ubuntu primary archive. Run from project dir; only one `.tar.gz` allowed. |
+| **ubuntu_orig_conflict.sh** | Check whether Ubuntu primary archive has a different `package_X.Y.Z.orig.tar.gz`. **Args:** `package version [local-orig-file]`. Exit 0 if vendor suffix recommended. Used by `auto_daily_project.sh`. |
 | **putarchive.sh** | Interactive: select .dsc, platform, and arch; run `dput local` to push built packages to a local archive. Expects pbuilder result in `../pbuilder/$szPlatform..._result/`. |
 
 ---
@@ -72,3 +73,35 @@ Scripts for building and publishing Debian/Ubuntu packages for rsyslog and relat
 - **PACKAGE_SIGNING_KEY_ID** – GPG key for signing packages and uploads.
 - **RS_NOTIFY_EMAIL** – Used by `auto_daily_project.sh` for failure notifications (mutt).
 - **KEY_ID** – Used by `prepare.sh` and `updaterelease.sh`; may be unset (consider aligning with `PACKAGE_SIGNING_KEY_ID`).
+
+---
+
+## Primary archive orig conflicts
+
+Launchpad rejects uploads when `package_X.Y.Z.orig.tar.gz` already exists in the Ubuntu primary archive with **different content** than your tarball (common when GitHub release tarballs differ from Debian repacks).
+
+**Normal release** (no conflict):
+
+```bash
+./repack.sh <github-release-url>
+./uploadppa.sh    # debuild -sa on first upload (SUBVERSION 1)
+```
+
+**Ubuntu primary conflict** (e.g. liblognorm 2.1.0):
+
+```bash
+./repack.sh https://github.com/rsyslog/liblognorm/releases/download/v2.1.0/liblognorm-2.1.0.tar.gz +adiscon1
+./uploadppa.sh    # SUBVERSION 1 + -sa per suite (noble, focal, jammy); SUBVERSION 2+ + -sd only after PPA accepted -sa
+```
+
+**SUBVERSION** is a per-suite counter (`noble1`, `noble2`, …). It resets to **1** when the upstream version changes (e.g. new `+adiscon1` suffix). Old `noble3` from rejected `2.1.0` uploads does not apply to `2.1.0+adiscon1`.
+
+| Situation | Action |
+|-----------|--------|
+| New upstream, not in Ubuntu primary | `repack.sh <url>` + `uploadppa.sh` + `-sa` |
+| GitHub tarball differs from Ubuntu for same `X.Y.Z` | `repack.sh <url> +adiscon1` + `uploadppa.sh` + `-sa` |
+| Packaging-only fix, vendor version already in PPA | same tree + `uploadppa.sh` + `-sd` |
+
+The `+adiscon1` suffix changes the **source package version** (e.g. `2.1.0+adiscon1-0adiscon1noble1`), not binary package names (`liblognorm5`, `liblognorm-dev`). Existing installations upgrade normally via `apt upgrade`.
+
+`auto_daily_project.sh` applies `+adiscon1` automatically when `ubuntu_orig_conflict.sh` detects a mismatch. It defaults to `debuild -sa` (CUSTOMBUILD is part of the upstream version, so each build needs its own orig). Pass a 5th argument `sd` only for packaging-only re-uploads when the orig is already on the PPA.

--- a/scripts/auto_daily_project.sh
+++ b/scripts/auto_daily_project.sh
@@ -20,13 +20,19 @@ szPlatform=$1		# trusty, vivid, ...
 UPLOAD_PPA=$2		# path of the ppa (e.g. v8-devel)
 BRANCH=$3		# branch to use (e.g. master)
 			# Note: this must match the tarball branch
-CUSTOMBUILD=${4:-""}	# Use if set, needed for rebuilds to make unique upload files
-# Append an underscore if CUSTOMBUILD is not empty
-if [ -n "$CUSTOMBUILD" ]; then
-    CUSTOMBUILD="-$CUSTOMBUILD"
+CUSTOMBUILD_ARG=${4:-""}
+DEBUILD_ARG=${5:-""}
+if [ -n "$CUSTOMBUILD_ARG" ]; then
+    CUSTOMBUILD="-$CUSTOMBUILD_ARG"
 else
     CUSTOMBUILD="-$(date +%Y%m%d%H%M%S)"
 fi
+# Always -sa by default: CUSTOMBUILD is part of upstream version (new .orig name each time).
+# Opt in to -sd only for packaging-only re-uploads when orig is already on the PPA.
+DEBUILD_MODE="-sa"
+case "$DEBUILD_ARG" in
+    -sd|sd) DEBUILD_MODE="-sd" ;;
+esac
 #if [ -z "$CUSTOMBUILD" ]; then
 #fi
 
@@ -98,10 +104,15 @@ rm -f $PROJECT_*.dsc
 rm -f $PROJECT_*.build
 rm -f $PROJECT_*.debian.tar.gz
 rm -f $PROJECT_*.orig.tar.gz
-# Delete LAUNCHPAD_VERSION Dir if it exists and is in the current working directory
+# Delete work dirs from previous runs (pre-vendor and vendor-suffixed names)
 if [[ -d "./$LAUNCHPAD_VERSION" ]]; then
 	echo "REMOVE existing directory $LAUNCHPAD_VERSION !"
 	rm -rf "./$LAUNCHPAD_VERSION"
+fi
+VENDOR_WORKDIR="${PROJECT}-${PURE_VERSION}+adiscon1${CUSTOMBUILD}"
+if [[ -d "./$VENDOR_WORKDIR" ]]; then
+	echo "REMOVE existing directory $VENDOR_WORKDIR !"
+	rm -rf "./$VENDOR_WORKDIR"
 fi
 
 # BEGIN ACTUAL BUILD PROCESS
@@ -112,8 +123,35 @@ if [ $? -ne 0 ]; then
 fi
 mv $szSourceFile $szReplaceFile.orig.tar.gz
 
-mv $szSourceBase $LAUNCHPAD_VERSION
-cd $LAUNCHPAD_VERSION
+# Vendor suffix when plain upstream version conflicts with Ubuntu primary archive
+VENDOR_SUFFIX=""
+SCRIPT_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || echo "$0")")
+if [ -f "$SCRIPT_DIR/ubuntu_orig_conflict.sh" ]; then
+    if bash "$SCRIPT_DIR/ubuntu_orig_conflict.sh" "$PROJECT" "$PURE_VERSION" "$szReplaceFile.orig.tar.gz"; then
+        VENDOR_SUFFIX="+adiscon1"
+        echo "Applying vendor suffix $VENDOR_SUFFIX (Ubuntu primary orig conflict)"
+        LAUNCHPAD_VERSION="${PURE_VERSION}${VENDOR_SUFFIX}${CUSTOMBUILD}"
+        szReplaceFile="${PROJECT}_${LAUNCHPAD_VERSION}"
+        VENDOR_ORIG="${szReplaceFile}.orig.tar.gz"
+        VENDOR_DIR="${PROJECT}-${LAUNCHPAD_VERSION}"
+        if [ -d "$szSourceBase" ]; then
+            mv "$szSourceBase" "$VENDOR_DIR" || { echo "Error: failed to rename source directory"; exit 1; }
+            szSourceBase="$VENDOR_DIR"
+        fi
+        tar czf "$VENDOR_ORIG" "$VENDOR_DIR" || { echo "Error: failed to create vendor orig tarball"; exit 1; }
+        rm -f "${PROJECT}_${PURE_VERSION}${CUSTOMBUILD}.orig.tar.gz"
+    fi
+fi
+
+if [ -n "$VENDOR_SUFFIX" ]; then
+    # Keep ${PROJECT}-${LAUNCHPAD_VERSION}/ — same top-level dir as in VENDOR_ORIG
+    SOURCE_WORKDIR="$szSourceBase"
+    cd "$SOURCE_WORKDIR"
+else
+    mv "$szSourceBase" "$LAUNCHPAD_VERSION"
+    SOURCE_WORKDIR="$LAUNCHPAD_VERSION"
+    cd "$SOURCE_WORKDIR"
+fi
 ls -l ..
 ls -l ../$szPlatform
 ls -l ../$szPlatform/$BRANCH
@@ -136,11 +174,11 @@ cat debian/changelog
 
 # Build Source package now!
 if [ -v PACKAGE_SIGNING_KEY_ID ]; then
-	echo "RUN debuild -S -sa -rfakeroot -k $PACKAGE_SIGNING_KEY_ID
-	debuild -S -sa -rfakeroot -k"$PACKAGE_SIGNING_KEY_ID"
+	echo "RUN debuild -S $DEBUILD_MODE -rfakeroot -k $PACKAGE_SIGNING_KEY_ID"
+	debuild -S $DEBUILD_MODE -rfakeroot -k"$PACKAGE_SIGNING_KEY_ID"
 else
-	echo "RUN debuild -S -sa -rfakeroot -us -uc
-        debuild -S -sa -rfakeroot -us -uc
+	echo "RUN debuild -S $DEBUILD_MODE -rfakeroot -us -uc"
+	debuild -S $DEBUILD_MODE -rfakeroot -us -uc
 fi
 if [ $? -ne 0 ]; then
 	echo "fail in debuild for $PROJECT_SONAME $VERSION on $szPlatform - check cron mail for details" | mutt -s "$PROJECT_SONAME daily build failed!" $RS_NOTIFY_EMAIL
@@ -164,6 +202,6 @@ if [ -v PACKAGE_SIGNING_KEY_ID ]; then
 	#cleanup
 	echo $VERSION >$VERSION_FILE
 	#exit # do this for testing
-	rm -rf $LAUNCHPAD_VERSION
+	rm -rf "$SOURCE_WORKDIR"
 	rm -v $szReplaceFile*.dsc $szReplaceFile*.build $szReplaceFile*.changes $szReplaceFile*.upload *.tar.gz
 fi

--- a/scripts/repack.sh
+++ b/scripts/repack.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
+# Usage: repack.sh <release-tarball-url> [vendor-suffix]
+# Example: repack.sh https://github.com/rsyslog/liblognorm/releases/download/v2.1.0/liblognorm-2.1.0.tar.gz +adiscon1
 echo download tar to be released: $1
+VENDOR_SUFFIX="${2:-}"
 
-rm -v *.tar.gz
+rm -fv *.tar.gz 2>/dev/null || true
 
-wget --no-check-certificate $1 
+wget --no-check-certificate "$1" || { echo "Error: wget failed"; exit 1; }
 
-TARGZFILE=`ls *.tar.gz`
+TARGZFILE=$(ls *.tar.gz 2>/dev/null || true)
 
-if [ `echo $TARGZFILE | wc -l` -ne 1 ]; then 
-   echo only a single source tar file is supported
+if [ -z "$TARGZFILE" ] || [ ! -f "$TARGZFILE" ]; then
+   echo "Error: expected exactly one .tar.gz after download."
    exit 1
 fi
 
@@ -22,5 +25,17 @@ szSourceBase=`basename $TARGZFILE .tar.gz`
 szReplaceFile=`echo $szSourceBase | sed 's/-/_/'`
 
 tar xfz $TARGZFILE
-mv $TARGZFILE $szReplaceFile.orig.tar.gz
+rm -f $TARGZFILE
 
+SOURCE_DIR="$szSourceBase"
+if [ -n "$VENDOR_SUFFIX" ]; then
+    echo "Applying vendor suffix: $VENDOR_SUFFIX"
+    szReplaceFile="${szReplaceFile}${VENDOR_SUFFIX}"
+    mv "$szSourceBase" "${szSourceBase}${VENDOR_SUFFIX}"
+    SOURCE_DIR="${szSourceBase}${VENDOR_SUFFIX}"
+fi
+
+# Orig tarball must contain the same top-level directory as the source tree
+tar czf "${szReplaceFile}.orig.tar.gz" "$SOURCE_DIR" || { echo "Error: failed to create orig tarball"; exit 1; }
+
+echo "Created ${szReplaceFile}.orig.tar.gz and ${SOURCE_DIR}/"

--- a/scripts/ubuntu_orig_conflict.sh
+++ b/scripts/ubuntu_orig_conflict.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Check whether Ubuntu primary archive has a different orig tarball for this version.
+# Usage: ubuntu_orig_conflict.sh <package> <version> [local-orig-file]
+# Exit 0 if vendor suffix is recommended, 1 if not needed or cannot determine, 2 on error.
+PACKAGE="$1"
+VERSION="$2"
+LOCAL_ORIG="${3:-}"
+
+if [ -z "$PACKAGE" ] || [ -z "$VERSION" ]; then
+    echo "Usage: ubuntu_orig_conflict.sh <package> <version> [local-orig-file]" >&2
+    exit 2
+fi
+
+# Pool directory: lib* packages use libX (e.g. liblognorm -> libl)
+if [[ "$PACKAGE" == lib* ]]; then
+    POOL_DIR="lib$(echo "$PACKAGE" | cut -c4)"
+else
+    POOL_DIR=$(echo "$PACKAGE" | cut -c1)
+fi
+UBUNTU_URL="https://archive.ubuntu.com/ubuntu/pool/universe/${POOL_DIR}/${PACKAGE}/${PACKAGE}_${VERSION}.orig.tar.gz"
+
+TMP_ORIG=$(mktemp)
+if ! wget -q -O "$TMP_ORIG" "$UBUNTU_URL" 2>/dev/null; then
+    rm -f "$TMP_ORIG"
+    exit 1
+fi
+
+if [ ! -s "$TMP_ORIG" ]; then
+    rm -f "$TMP_ORIG"
+    exit 1
+fi
+
+UBUNTU_SHA=$(sha256sum "$TMP_ORIG" | awk '{print $1}')
+
+if [ -n "$LOCAL_ORIG" ] && [ -f "$LOCAL_ORIG" ]; then
+    LOCAL_SHA=$(sha256sum "$LOCAL_ORIG" | awk '{print $1}')
+    rm -f "$TMP_ORIG"
+    if [ "$LOCAL_SHA" != "$UBUNTU_SHA" ]; then
+        echo "Ubuntu primary has ${PACKAGE}_${VERSION}.orig.tar.gz with different content (vendor suffix recommended)" >&2
+        exit 0
+    fi
+    exit 1
+fi
+
+rm -f "$TMP_ORIG"
+echo "Ubuntu primary has ${PACKAGE}_${VERSION}.orig.tar.gz (vendor suffix may be required for non-Ubuntu tarballs)" >&2
+exit 0

--- a/scripts/uploadppa.sh
+++ b/scripts/uploadppa.sh
@@ -6,11 +6,11 @@ source $(dirname "$0")/config.sh
 
 # If we assume the directory is named after the package,
 PACKAGENAME=$(basename `readlink -f .`)
-TARGZFILES=` ls -d */ | grep $PACKAGENAME`
+TARGZFILES=$(find . -maxdepth 1 -type d -name "${PACKAGENAME}-*" | sort)
 echo TARG: $TARGZFILES
 
-if [ `echo $TARGZFILES | wc -l` -ne 1 ]; then 
-   echo only a single source tar file is supported
+if [ "$(printf '%s\n' "$TARGZFILES" | sed '/^$/d' | wc -l)" -ne 1 ] || [ ! -d "$TARGZFILES" ]; then
+   echo "Error: expected exactly one ${PACKAGENAME}-* source directory."
    exit 1
 fi
 
@@ -48,20 +48,20 @@ do
     echo "Invalid selection. Please try again."
 done
 
-# Get VERSION from the tarball name
-VERSION=$(echo $TARGZFILES | grep -oP '(?<=-)[0-9]+\.[0-9]+\.[0-9]+')
+# Get upstream version from source directory name (e.g. liblognorm-2.1.0+adiscon1/)
+UPSTREAM_VERSION=$(basename "$TARGZFILES" | sed "s/^${PACKAGENAME}-//" | sed 's|/$||')
 
-if [ -z "$VERSION" ]; then
-    echo "Unable to determine version from tarball name."
+if [ -z "$UPSTREAM_VERSION" ] || [ "$UPSTREAM_VERSION" = "." ] || [ ! -d "$szPrepareDir" ]; then
+    echo "Unable to determine upstream version or source directory does not exist."
     exit 1
 fi
 
 echo "Using PPA: $UPLOAD_PPA"
 echo "Using Debian branch: $szBranch"
-echo "Detected VERSION: $VERSION"
+echo "Detected UPSTREAM_VERSION: $UPSTREAM_VERSION"
 
 echo "REMOVE / CLEANUP Existing $szPrepareDir/debian"
-rm -r $szPrepareDir/debian
+rm -r "$szPrepareDir/debian"
 
 echo "COPY $szPlatform/$szBranch/debian to $szPrepareDir/debian"
 cp -r $szPlatform/$szBranch/debian $szPrepareDir || exit 1
@@ -69,13 +69,25 @@ cp -r $szPlatform/$szBranch/debian $szPrepareDir || exit 1
 read -p "Generate Changelog entry for $szPlatform/$szBranch automatically (y/n)? " GEN_CHANGELOG
 cd $szPrepareDir
 if [ "$GEN_CHANGELOG" == "y" ]; then
+    echo ""
+    echo "=== SUBVERSION (per Ubuntu suite) ==="
+    echo "Counter for packaging revisions on THIS suite only (noble, focal, ...)."
+    echo "It becomes part of the Debian version, e.g. 2.1.0+adiscon1-0adiscon1noble1."
+    echo ""
+    echo "  SUBVERSION 1  = first upload of this upstream version to this suite"
+    echo "                  (new release or new vendor suffix like +adiscon1)"
+    echo "  SUBVERSION 2+ = packaging-only fix; same source tarball as before"
+    echo ""
+    echo "If you changed the upstream version (e.g. plain 2.1.0 -> 2.1.0+adiscon1),"
+    echo "always start at 1 for each suite — old noble2/noble3 entries do not carry over."
+    echo ""
     read -p "Enter SUBVERSION number (default is 1): " SUBVERSION
     SUBVERSION=${SUBVERSION:-1}
     echo "Using SUBVERSION: $SUBVERSION"
 
-    NEW_ENTRY="$PACKAGENAME ($VERSION-0adiscon1$szPlatform$SUBVERSION) $szPlatform; urgency=low
+    NEW_ENTRY="$PACKAGENAME ($UPSTREAM_VERSION-0adiscon1$szPlatform$SUBVERSION) $szPlatform; urgency=low
 
-  * Packages for ${VERSION} on ${szPlatform}
+  * Packages for ${UPSTREAM_VERSION} on ${szPlatform}
 
  -- Adiscon package maintainers <adiscon-pkg-maintainers@adiscon.com>  $(date -R)"
     echo -e "$NEW_ENTRY\n$(cat debian/changelog)" > debian/changelog
@@ -86,18 +98,41 @@ else
     if [ "$GEN_CHANGELOG" == "y" ]; then
         dch -D $szPlatform -i
     fi
+    SUBVERSION=1
 fi
+
+# debuild -sa uploads the .orig.tar.gz; -sd uploads only debian/ changes (manual opt-in)
+DEBUILD_MODE="-sa"
+
+echo ""
+echo "=== debuild mode ==="
+echo "  -sa  Include ${PACKAGENAME}_${UPSTREAM_VERSION}.orig.tar.gz in the upload. (default)"
+echo "       Use for SUBVERSION 1 and whenever unsure."
+echo "  -sd  Upload only debian/ changes; Launchpad reuses the orig from a prior upload."
+echo "       Only use for SUBVERSION 2+ AFTER -sa was already accepted on the PPA."
+echo ""
+if [ "${SUBVERSION:-1}" -gt 1 ] 2>/dev/null; then
+    echo "NOTE: SUBVERSION > 1 — you may type -sd if the orig is already on the PPA."
+    echo "      Default stays -sa (safer if unsure)."
+fi
+echo ""
+read -p "debuild mode: -sa (include orig) or -sd (packaging-only) [-sa]? " MODE
+case "${MODE}" in
+    -sd) DEBUILD_MODE="-sd" ;;
+    ""|-sa) DEBUILD_MODE="-sa" ;;
+    *) echo "Invalid debuild mode: ${MODE}"; exit 1 ;;
+esac
 
 # Build Source package now!
 if [ -v PACKAGE_SIGNING_KEY_ID ]; then
-    echo "RUN debuild -S -sa -rfakeroot -k $PACKAGE_SIGNING_KEY_ID"
-    debuild -S -sa -rfakeroot -k"$PACKAGE_SIGNING_KEY_ID"
+    echo "RUN debuild -S $DEBUILD_MODE -rfakeroot -k $PACKAGE_SIGNING_KEY_ID"
+    debuild -S "$DEBUILD_MODE" -rfakeroot -k"$PACKAGE_SIGNING_KEY_ID"
 else
-    echo "RUN WITHOUT KEY debuild -S -sa -rfakeroot -us -uc"
-    debuild -S -sa -rfakeroot -us -uc
+    echo "RUN WITHOUT KEY debuild -S $DEBUILD_MODE -rfakeroot -us -uc"
+    debuild -S "$DEBUILD_MODE" -rfakeroot -us -uc
 fi
 if [ $? -ne 0 ]; then
-    echo "FAIL in debuild for $PACKAGENAME $VERSION on $szPlatform"
+    echo "FAIL in debuild for $PACKAGENAME $UPSTREAM_VERSION on $szPlatform"
     exit 1
 fi
 


### PR DESCRIPTION
… conflicts

+ rsyslog 8.2606.0 release build
+ liblognorm 2.1.0 release build

Launchpad rejects PPA uploads when package_X.Y.Z.orig.tar.gz already exists in the Ubuntu primary archive with different content than our GitHub release tarball. liblognorm 2.1.0 is affected: the GitHub tarball (~790 KB) differs from Ubuntu's Debian repack (~423 KB).

Introduce a vendor upstream version suffix (+adiscon1) so we can upload the full GitHub release under a new orig filename
(e.g. liblognorm_2.1.0+adiscon1.orig.tar.gz) without colliding with Ubuntu's liblognorm_2.1.0.orig.tar.gz. Binary package names are unchanged; only the source package version string changes.

repack.sh:
- Add optional second argument for vendor suffix (+adiscon1)
- Rename extracted source directory to match vendor version
- Rebuild .orig.tar.gz so its top-level directory matches the source tree (fixes dpkg-source failures when inner paths disagreed)
- Tolerate missing *.tar.gz on cleanup

uploadppa.sh:
- Derive UPSTREAM_VERSION from source directory name (supports +suffix)
- Add interactive help for SUBVERSION (per-suite packaging counter)
- Prompt for debuild -sa vs -sd; default always -sa (safer)
- Use selected mode instead of hardcoded -sa

auto_daily_project.sh:
- Auto-apply +adiscon1 when ubuntu_orig_conflict.sh detects mismatch
- Rebuild vendor orig tarball with correct inner directory name
- Use debuild -sd only when CUSTOMBUILD is passed (rebuilds)
- Fix broken debuild echo/command syntax

ubuntu_orig_conflict.sh (new):
- Compare local orig SHA256 against Ubuntu pool copy
- Exit 0 when vendor suffix is recommended

DOC.md:
- Document orig conflict workflow, SUBVERSION rules, and -sa/-sd usage

liblognorm changelogs:
- Record 2.1.0+adiscon1 uploads for noble and jammy (v8-stable)

Usage for liblognorm 2.1.0:
  ./repack.sh <github-release-url> +adiscon1
  ./uploadppa.sh   # SUBVERSION 1 per suite, default -sa